### PR TITLE
Add flake8 config file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,13 @@
+[flake8]
+select = B,C,E,F,P,T4,W,B9
+max-line-length = 120
+# C408 ignored because we like the dict keyword argument syntax
+# E501 is not flexible enough, we're using B950 instead
+ignore =
+    E203,E305,E402,E501,E721,E741,F403,F405,F821,F841,F999,W503,W504,C408,E302,W291,E303,
+    # these ignores are from flake8-bugbear; please fix!
+    B007,B008,
+    # these ignores are from flake8-comprehensions; please fix!
+    C400,C401,C402,C403,C404,C405,C407,C411,
+per-file-ignores = __init__.py: F401
+exclude = .git


### PR DESCRIPTION
Everything is in the name.
It the same rules than pytorch's https://github.com/pytorch/pytorch/blob/master/.flake8 so contributor wont be disoriented.