### PR TITLE
Simplify nv-usd setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,7 @@ def build_deps():
     #     f.write('__version__ = \'{}\'\n'.format(version))
 
     # build nv-usd
-    sp = site.getsitepackages()[0]
     os.system('./buildusd.sh')
-    lib = Path.cwd() / 'build/target-deps/nv_usd/release/lib/'
-    os.system(f'ln -s {str(lib)}/python/ {sp}')
 
 
 def read(*names, **kwargs):


### PR DESCRIPTION
Remove linking to site packages which breaks when
using virtualenv. Instead will rely on the setenv.sh script.