### PR TITLE
Fix shapenet

### DIFF
--- a/kaolin/datasets/shapenet.py
+++ b/kaolin/datasets/shapenet.py
@@ -105,7 +105,7 @@ def tqdm_hook(t, timeout=1):
 
 
 def download_shapenet_class(syn: str, shapenet_location: str, download: bool):
-    r"""Downloads a shapenet to a specified directory.
+    r"""Downloads a shapenet class to a specified directory.
 
     You may complete this function to automate downloading from a
     central source.
@@ -113,7 +113,7 @@ def download_shapenet_class(syn: str, shapenet_location: str, download: bool):
     NotImplemented
 
 
-def download_images(shapenet_root: str):
+def download_images(shapenet_location: str):
     r"""Downloads shapenet core class images to a specified directory
 
     You may complete this function to automate downloading from a
@@ -155,7 +155,7 @@ class ShapeNet_Meshes(data.Dataset):
         }
 
     Example:
-        >>> meshes = ShapeNet_Meshes(root='./datasets/ShapeNet/', download=True)
+        >>> meshes = ShapeNet_Meshes(root='../data/ShapeNet/', download=True)
         >>> obj = next(iter(meshes))
         >>> obj['data']['vertices'].shape
         torch.Size([2133, 3])
@@ -243,7 +243,7 @@ class ShapeNet_Images(data.Dataset):
 
     Example:
         >>> from torch.utils.data import DataLoader
-        >>> images = ShapeNet_Images(root ='./datasets/', download = True)
+        >>> images = ShapeNet_Images(root='../data/ShapeNetImages', download = True)
         >>> train_loader = DataLoader(images, batch_size=10, shuffle=True, num_workers=8)
         >>> obj = next(iter(train_loader))
         >>> image = obj['data']['imgs']
@@ -254,20 +254,20 @@ class ShapeNet_Images(data.Dataset):
     def __init__(self, root: str, categories: list = ['chair'], train: bool = True,
                  split: float = .7, download: bool = True, views: int = 23, transform=None,
                  no_progress: bool = False):
-        self.root = root
+        self.root = Path(root)
         self.synsets = _convert_categories(categories)
+        self.labels = [synset_to_label[s] for s in self.synsets]
         self.transform = transform
         self.views = views
         self.names = []
         self.synset_idx = []
 
-        self.shapenet_root = Path(root) / 'ShapeNet'
-        shapenet_img_root = Path(self.shapenet_root) / 'images'
+        shapenet_img_root = self.root / 'images'
         # check if images already exists and if not download them
         if not shapenet_img_root.exists():
             shapenet_img_root.mkdir()
             assert download, f'ShapeNet Images are not found, and download is set to False'
-            download_images(str(self.shapenet_root))
+            download_images(str(self.root))
 
         # find all needed images
         for i in tqdm(range(len(self.synsets)), disable=no_progress):
@@ -320,7 +320,7 @@ class ShapeNet_Images(data.Dataset):
         data['params']['distance'] = distance
         attributes['name'] = name
         attributes['synset'] = self.synsets[synset_idx]
-        attributes['label'] = self.synsets[self.synset_idx[index]]
+        attributes['label'] = self.labels[self.synset_idx[index]]
         return {'data': data, 'attributes': attributes}
 
 

--- a/kaolin/datasets/shapenet.py
+++ b/kaolin/datasets/shapenet.py
@@ -155,7 +155,7 @@ class ShapeNet_Meshes(data.Dataset):
         }
 
     Example:
-        >>> meshes = ShapeNet_Meshes(root='./datasets/ShapeNet/', cache_dir='cache', download=True)
+        >>> meshes = ShapeNet_Meshes(root='./datasets/ShapeNet/', download=True)
         >>> obj = next(iter(meshes))
         >>> obj['data']['vertices'].shape
         torch.Size([2133, 3])
@@ -163,7 +163,7 @@ class ShapeNet_Meshes(data.Dataset):
         torch.Size([1910, 3])
     """
 
-    def __init__(self, root: str, cache_dir: str, categories: list = ['chair'], train: bool = True,
+    def __init__(self, root: str, categories: list = ['chair'], train: bool = True,
                  download: bool = False, split: float = .7, no_progress: bool = False):
         self.root = Path(root)
         self.paths = []
@@ -176,7 +176,7 @@ class ShapeNet_Meshes(data.Dataset):
             syn = self.synsets[i]
             class_target = self.root / syn
             if not class_target.exists():
-                download_shapenet(syn, str(self.root), download)
+                download_shapenet_class(syn, str(self.root), download)
 
             # find all objects in the class
             models = sorted(class_target.glob('*'))
@@ -251,7 +251,7 @@ class ShapeNet_Images(data.Dataset):
         torch.Size([10, 4, 137, 137])
     """
 
-    def __init__(self, root: str, cache_dir: str, categories: list = ['chair'], train: bool = True,
+    def __init__(self, root: str, categories: list = ['chair'], train: bool = True,
                  split: float = .7, download: bool = True, views: int = 23, transform=None,
                  no_progress: bool = False):
         self.root = root
@@ -329,6 +329,7 @@ class ShapeNet_Voxels(data.Dataset):
 
     Args:
         root (str): Path to the root directory of the ShapeNet dataset.
+        cache_dir (str): Path to save cached converted representations.
         categories (str): List of categories to load from ShapeNet. This list may
                 contain synset ids, class label names (for ShapeNetCore classes),
                 or a combination of both.
@@ -365,7 +366,6 @@ class ShapeNet_Voxels(data.Dataset):
             'resolutions': resolutions,
         }
         mesh_dataset = ShapeNet_Meshes(root=root,
-                                       cache_dir=cache_dir,
                                        categories=categories,
                                        train=train,
                                        download=download,
@@ -416,6 +416,7 @@ class ShapeNet_Surface_Meshes(data.Dataset):
 
     Arguments:
         root (str): Path to the root directory of the ShapeNet dataset.
+        cache_dir (str): Path to save cached converted representations.
         categories (str): List of categories to load from ShapeNet. This list may
                 contain synset ids, class label names (for ShapeNetCore classes),
                 or a combination of both.
@@ -453,7 +454,6 @@ class ShapeNet_Surface_Meshes(data.Dataset):
         self.cache_dir = Path(cache_dir) / 'surface_meshes'
         dataset_params = {
             'root': root,
-            'cache_dir': cache_dir,
             'categories': categories,
             'train': train,
             'download': download,
@@ -467,7 +467,7 @@ class ShapeNet_Surface_Meshes(data.Dataset):
         }
 
         mesh_dataset = ShapeNet_Meshes(**dataset_params)
-        voxel_dataset = ShapeNet_Voxels(**dataset_params, resolutions=[resolution])
+        voxel_dataset = ShapeNet_Voxels(**dataset_params, cache_dir=cache_dir, resolutions=[resolution])
         combined_dataset = ShapeNet_Combination([mesh_dataset, voxel_dataset])
 
         self.names = combined_dataset.names
@@ -529,6 +529,7 @@ class ShapeNet_Points(data.Dataset):
 
     Args:
         root (str): Path to the root directory of the ShapeNet dataset.
+        cache_dir (str): Path to save cached converted representations.
         categories (str): List of categories to load from ShapeNet. This list may
                 contain synset ids, class label names (for ShapeNetCore classes),
                 or a combination of both.
@@ -568,7 +569,6 @@ class ShapeNet_Points(data.Dataset):
 
         dataset_params = {
             'root': root,
-            'cache_dir': cache_dir,
             'categories': categories,
             'train': train,
             'download': download,
@@ -585,6 +585,7 @@ class ShapeNet_Points(data.Dataset):
 
         if surface:
             dataset = ShapeNet_Surface_Meshes(**dataset_params,
+                                              cache_dir=cache_dir,
                                               resolution=resolution,
                                               smoothing_iterations=smoothing_iterations)
         else:
@@ -637,6 +638,7 @@ class ShapeNet_SDF_Points(data.Dataset):
 
     Args:
         root (str): Path to the root directory of the ShapeNet dataset.
+        cache_dir (str): Path to save cached converted representations.
         categories (str): List of categories to load from ShapeNet. This list may
                 contain synset ids, class label names (for ShapeNetCore classes),
                 or a combination of both.

--- a/tests/datasets/test_ShapeNet.py
+++ b/tests/datasets/test_ShapeNet.py
@@ -15,7 +15,6 @@
 import pytest
 
 import torch
-import sys
 import os
 import shutil
 from pathlib import Path
@@ -25,13 +24,15 @@ from torch.utils.data import DataLoader
 from kaolin.datasets import shapenet
 
 
-# Tests below can only be run is a ShapeNet dataset is available
-
-
 SHAPENET_ROOT = 'data/ShapeNet/'
 CACHE_DIR = 'tests/datasets/cache'
 
 
+# Tests below can only be run is a ShapeNet dataset is available
+REASON = 'ShapeNet not found at {}'.format(SHAPENET_ROOT)
+
+
+@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)
 def test_Meshes():
     meshes1 = shapenet.ShapeNet_Meshes(root=SHAPENET_ROOT,
                                        categories=['can'], train=True, split=.7)
@@ -45,6 +46,7 @@ def test_Meshes():
     assert len(meshes2) > len(meshes1)
 
 
+@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)
 def test_Voxels():
     voxels = shapenet.ShapeNet_Voxels(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
                                       categories=['can'], train=True, split=.7, resolutions=[32])
@@ -73,6 +75,7 @@ def test_Voxels():
 #         assert set(obj['data']['params']['cam_pos'].shape) == set([3])
 
 
+@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)
 def test_Surface_Meshes():
     surface_meshes = shapenet.ShapeNet_Surface_Meshes(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
                                                       categories=['can'], train=True, split=.1,
@@ -101,6 +104,7 @@ def test_Surface_Meshes():
     shutil.rmtree('tests/datasets/cache/surface_meshes')
 
 
+@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)
 def test_Points():
     points = shapenet.ShapeNet_Points(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
                                       categories=['can'], train=True, split=.1,
@@ -133,6 +137,7 @@ def test_Points():
     shutil.rmtree('tests/datasets/cache/surface_meshes')
 
 
+@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)
 def test_SDF_Points():
     sdf_points = shapenet.ShapeNet_SDF_Points(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
                                               categories=['can'], train=True, split=.1,
@@ -165,6 +170,7 @@ def test_SDF_Points():
     shutil.rmtree('tests/datasets/cache/surface_meshes')
 
 
+@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)
 def test_Combination():
     dataset_params = {
         'root': SHAPENET_ROOT,

--- a/tests/datasets/test_ShapeNet.py
+++ b/tests/datasets/test_ShapeNet.py
@@ -29,7 +29,7 @@ CACHE_DIR = 'tests/datasets/cache'
 
 
 # Tests below can only be run is a ShapeNet dataset is available
-REASON = 'ShapeNet not found at {}'.format(SHAPENET_ROOT)
+REASON = 'ShapeNet not found at default location: {}'.format(SHAPENET_ROOT)
 
 
 @pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)

--- a/tests/datasets/test_ShapeNet.py
+++ b/tests/datasets/test_ShapeNet.py
@@ -27,44 +27,43 @@ from kaolin.datasets import shapenet
 
 # Tests below can only be run is a ShapeNet dataset is available
 
-# def test_download_shapenet_class():
-#     shapenet.download_shapenet_class('02946921', 'datasets', True)
-#     assert os.path.exists('datasets/02946921')
-#     shapenet.download_shapenet_class('02946921', 'datasets', True)
-#     assert os.path.exists('datasets/02946921')
-#     shutil.rmtree('datasets/02946921')
+
+SHAPENET_ROOT = 'data/ShapeNet/'
+CACHE_DIR = 'tests/datasets/cache'
 
 
-# def test_Meshes():
-#     meshes1 = shapenet.ShapeNet_Meshes(root='tests/datasets_eval', categories=['can'], train=True, split=.7)
-#     assert len(meshes1) > 0
-#     for mesh in meshes1:
-#         assert Path(mesh['attributes']['path']).is_file()
-#         assert mesh['data']['vertices'].shape[0] > 0
+def test_Meshes():
+    meshes1 = shapenet.ShapeNet_Meshes(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+                                       categories=['can'], train=True, split=.7)
+    assert len(meshes1) > 0
+    for mesh in meshes1:
+        assert Path(mesh['attributes']['path']).is_file()
+        assert mesh['data']['vertices'].shape[0] > 0
 
-#     meshes2 = shapenet.ShapeNet_Meshes(root='tests/datasets_eval', categories=['can', 'bowl'], train=True, split=.7)
-#     assert len(meshes2) > len(meshes1)
+    meshes2 = shapenet.ShapeNet_Meshes(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+                                       categories=['can', 'bowl'], train=True, split=.7)
+    assert len(meshes2) > len(meshes1)
 
 
-# def test_Voxels():
-#     voxels = shapenet.ShapeNet_Voxels(root='tests/datasets_eval', categories=['can'], train=True, split=.7,
-#                                       resolutions=[32])
-#     assert len(voxels) == 75
-#     assert voxels.cache_dir.exists()
-#     assert len(list(voxels.cache_dir.rglob('*.npz'))) == 75
-#     for obj in voxels:
-#         # assert os.path.isfile(obj['32_name'])
-#         assert (set(obj['data']['32'].shape) == set([32, 32, 32]))
+def test_Voxels():
+    voxels = shapenet.ShapeNet_Voxels(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+                                      categories=['can'], train=True, split=.7, resolutions=[32])
+    assert len(voxels) == 75
+    assert voxels.cache_dir.exists()
+    assert len(list(voxels.cache_dir.rglob('*.npz'))) == 75
+    for obj in voxels:
+        # assert os.path.isfile(obj['32_name'])
+        assert (set(obj['data']['32'].shape) == set([32, 32, 32]))
 
-#     voxels = shapenet.ShapeNet_Voxels(root='tests/datasets_eval', categories=['can'], train=False, split=.7,
-#                                       resolutions=[32])
-#     assert len(voxels) == 33
+    voxels = shapenet.ShapeNet_Voxels(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+                                      categories=['can'], train=False, split=.7, resolutions=[32])
+    assert len(voxels) == 33
 
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/voxels')
+    shutil.rmtree('tests/datasets/cache/voxels')
 
 
 # def test_Images():
-#     images = shapenet.ShapeNet_Images(root='tests/datasets_eval', categories=['phone'], views=1, train=True, split=.7)
+#     images = shapenet.ShapeNet_Images(root=SHAPENET_ROOT, cache_dir=CACHE_DIR, categories=['phone'], views=1, train=True, split=.7)
 #     assert len(images) == 736
 #     for obj in images:
 #         assert set(obj['data']['images'].shape) == set([137, 137, 4])
@@ -73,132 +72,132 @@ from kaolin.datasets import shapenet
 #         assert set(obj['data']['params']['cam_pos'].shape) == set([3])
 
 
-# def test_Surface_Meshes():
-#     surface_meshes = shapenet.ShapeNet_Surface_Meshes(root='tests/datasets_eval', categories=['can'], train=True, split=.1,
-#                                                       resolution=100, smoothing_iterations=3, mode='Tri')
-#     assert len(surface_meshes) == 10
-#     assert surface_meshes.cache_dir.exists()
-#     assert len(list(surface_meshes.cache_dir.rglob('*.npz'))) == 10
-#     for smesh in surface_meshes:
-#         assert smesh['data']['vertices'].shape[0] > 0
-#         assert smesh['data']['faces'].shape[1] == 3
+def test_Surface_Meshes():
+    surface_meshes = shapenet.ShapeNet_Surface_Meshes(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+                                                      categories=['can'], train=True, split=.1, resolution=100,
+                                                      smoothing_iterations=3, mode='Tri')
+    assert len(surface_meshes) == 10
+    assert surface_meshes.cache_dir.exists()
+    assert len(list(surface_meshes.cache_dir.rglob('*.npz'))) == 10
+    for smesh in surface_meshes:
+        assert smesh['data']['vertices'].shape[0] > 0
+        assert smesh['data']['faces'].shape[1] == 3
 
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/surface_meshes')
+    shutil.rmtree('tests/datasets/cache/surface_meshes')
 
-#     surface_meshes = shapenet.ShapeNet_Surface_Meshes(root='tests/datasets_eval', categories=['can'], train=True, split=.1,
-#                                                       resolution=100, smoothing_iterations=3, mode='Quad')
-#     assert len(surface_meshes) == 10
-#     assert surface_meshes.cache_dir.exists()
-#     assert len(list(surface_meshes.cache_dir.rglob('*.npz'))) == 10
-#     for smesh in surface_meshes:
-#         assert smesh['data']['vertices'].shape[0] > 0
-#         assert smesh['data']['faces'].shape[1] == 4
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/voxels')
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/surface_meshes')
-
-
-# def test_Points():
-#     points = shapenet.ShapeNet_Points(root='tests/datasets_eval', categories=['can'], train=True, split=.1,
-#                                       resolution=100, smoothing_iterations=3, num_points=5000,
-#                                       surface=False, normals=False)
-
-#     assert len(points) == 10
-#     assert points.cache_dir.exists()
-#     assert len(list(points.cache_dir.rglob('*.npz'))) == 10
-#     for obj in points:
-#         assert set(obj['data']['points'].shape) == set([5000, 3])
-#         assert set(obj['data']['normals'].shape) == set([5000, 3])
-
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/points')
-
-#     points = shapenet.ShapeNet_Points(root='tests/datasets_eval', categories=['can'], train=True, split=.1,
-#                                       resolution=100, smoothing_iterations=3, num_points=5000,
-#                                       surface=True, normals=True)
-
-#     assert len(points) == 10
-#     assert points.cache_dir.exists()
-#     assert len(list(points.cache_dir.rglob('*.npz'))) == 10
-#     for obj in points:
-#         assert set(obj['data']['points'].shape) == set([5000, 3])
-#         assert set(obj['data']['normals'].shape) == set([5000, 3])
-
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/points')
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/voxels')
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/surface_meshes')
+    surface_meshes = shapenet.ShapeNet_Surface_Meshes(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+                                                      categories=['can'], train=True, split=.1, resolution=100,
+                                                      smoothing_iterations=3, mode='Quad')
+    assert len(surface_meshes) == 10
+    assert surface_meshes.cache_dir.exists()
+    assert len(list(surface_meshes.cache_dir.rglob('*.npz'))) == 10
+    for smesh in surface_meshes:
+        assert smesh['data']['vertices'].shape[0] > 0
+        assert smesh['data']['faces'].shape[1] == 4
+    shutil.rmtree('tests/datasets/cache/voxels')
+    shutil.rmtree('tests/datasets/cache/surface_meshes')
 
 
-# def test_SDF_Points():
-#     sdf_points = shapenet.ShapeNet_SDF_Points(root='tests/datasets_eval', categories=['can'], train=True, split=.1,
-#                                               resolution=100, smoothing_iterations=3,
-#                                               num_points=5000, occ=False, sample_box=True)
+def test_Points():
+    points = shapenet.ShapeNet_Points(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+                                      categories=['can'], train=True, split=.1,
+                                      resolution=100, smoothing_iterations=3, num_points=5000,
+                                      surface=False, normals=False)
 
-#     assert len(sdf_points) == 10
-#     assert sdf_points.cache_dir.exists()
-#     assert len(list(sdf_points.cache_dir.rglob('*.npz'))) == 10
-#     for obj in sdf_points:
-#         assert set(obj['data']['sdf_points'].shape) == set([5000, 3])
-#         assert set(obj['data']['sdf_distances'].shape) == set([5000])
+    assert len(points) == 10
+    assert points.cache_dir.exists()
+    assert len(list(points.cache_dir.rglob('*.npz'))) == 10
+    for obj in points:
+        assert set(obj['data']['points'].shape) == set([5000, 3])
+        assert set(obj['data']['normals'].shape) == set([5000, 3])
 
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/sdf_points')
+    shutil.rmtree('tests/datasets/cache/points')
 
-#     sdf_points = shapenet.ShapeNet_SDF_Points(root='tests/datasets_eval', categories=['can'], train=True, split=.1,
-#                                               resolution=100, smoothing_iterations=3,
-#                                               num_points=5000, occ=True, sample_box=True)
+    points = shapenet.ShapeNet_Points(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+                                      categories=['can'], train=True, split=.1,
+                                      resolution=100, smoothing_iterations=3, num_points=5000,
+                                      surface=True, normals=True)
 
-#     assert len(sdf_points) == 10
-#     assert sdf_points.cache_dir.exists()
-#     assert len(list(sdf_points.cache_dir.rglob('*.npz'))) == 10
-#     for obj in sdf_points:
-#         assert set(obj['data']['occ_points'].shape) == set([5000, 3])
-#         assert set(obj['data']['occ_values'].shape) == set([5000])
+    assert len(points) == 10
+    assert points.cache_dir.exists()
+    assert len(list(points.cache_dir.rglob('*.npz'))) == 10
+    for obj in points:
+        assert set(obj['data']['points'].shape) == set([5000, 3])
+        assert set(obj['data']['normals'].shape) == set([5000, 3])
 
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/sdf_points')
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/voxels')
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/surface_meshes')
+    shutil.rmtree('tests/datasets/cache/points')
+    shutil.rmtree('tests/datasets/cache/voxels')
+    shutil.rmtree('tests/datasets/cache/surface_meshes')
 
 
-# def test_Combination():
-#     dataset_params = {
-#         'root': 'tests/datasets_eval',
-#         'categories': ['can'],
-#         'train': True,
-#         'split': .8,
-#     }
-#     # images = shapenet.ShapeNet_Images(root='tests/datasets_eval', categories=['bowl'], views=1, train=True, split=.8)
-#     meshes = shapenet.ShapeNet_Meshes(**dataset_params)
-#     voxels = shapenet.ShapeNet_Voxels(**dataset_params, resolutions=[32])
-#     sdf_points = shapenet.ShapeNet_SDF_Points(**dataset_params, smoothing_iterations=3, num_points=500, occ=False,
-#                                               sample_box=True)
+def test_SDF_Points():
+    sdf_points = shapenet.ShapeNet_SDF_Points(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+                                              categories=['can'], train=True, split=.1,
+                                              resolution=100, smoothing_iterations=3,
+                                              num_points=5000, occ=False, sample_box=True)
 
-#     points = shapenet.ShapeNet_Points(**dataset_params, resolution=100, smoothing_iterations=3, num_points=500,
-#                                       surface=False, normals=True)
+    assert len(sdf_points) == 10
+    assert sdf_points.cache_dir.exists()
+    assert len(list(sdf_points.cache_dir.rglob('*.npz'))) == 10
+    for obj in sdf_points:
+        assert set(obj['data']['sdf_points'].shape) == set([5000, 3])
+        assert set(obj['data']['sdf_distances'].shape) == set([5000])
 
-#     dataset = shapenet.ShapeNet_Combination([voxels, sdf_points, points])
+    shutil.rmtree('tests/datasets/cache/sdf_points')
 
-#     for obj in dataset:
-#         obj_data = obj['data']
-#         assert set(obj['data']['sdf_points'].shape) == set([500, 3])
-#         assert set(obj['data']['sdf_distances'].shape) == set([500])
-#         assert set(obj['data']['32'].shape) == set([32, 32, 32])
-#         assert set(obj['data']['imgs'].shape) == set([137, 137, 4])
-#         assert set(obj['data']['cam_mat'].shape) == set([3, 3])
-#         assert set(obj['data']['cam_pos'].shape) == set([3])
-#         assert set(obj['data']['points'].shape) == set([500, 3])
-#         assert set(obj['data']['normals'].shape) == set([500, 3])
+    sdf_points = shapenet.ShapeNet_SDF_Points(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+                                              categories=['can'], train=True, split=.1,
+                                              resolution=100, smoothing_iterations=3,
+                                              num_points=5000, occ=True, sample_box=True)
 
-#     train_loader = DataLoader(dataset, batch_size=2, shuffle=True, num_workers=8)
-#     for batch in train_loader:
-#         assert set(batch['data']['sdf_points'].shape) == set([2, 500, 3])
-#         assert set(batch['data']['sdf_distances'].shape) == set([2, 500])
-#         assert set(batch['data']['32'].shape) == set([2, 32, 32, 32])
-#         assert set(batch['data']['imgs'].shape) == set([2, 137, 137, 4])
-#         assert set(batch['data']['cam_mat'].shape) == set([2, 3, 3])
-#         assert set(batch['data']['cam_pos'].shape) == set([2, 3])
-#         assert set(batch['data']['points'].shape) == set([2, 500, 3])
-#         assert set(batch['data']['normals'].shape) == set([2, 500, 3])
+    assert len(sdf_points) == 10
+    assert sdf_points.cache_dir.exists()
+    assert len(list(sdf_points.cache_dir.rglob('*.npz'))) == 10
+    for obj in sdf_points:
+        assert set(obj['data']['occ_points'].shape) == set([5000, 3])
+        assert set(obj['data']['occ_values'].shape) == set([5000])
 
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/sdf_points')
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/points')
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/voxels')
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/surface_meshes')
-#     shutil.rmtree('tests/datasets_eval/ShapeNet/meshes')
+    shutil.rmtree('tests/datasets/cache/sdf_points')
+    shutil.rmtree('tests/datasets/cache/voxels')
+    shutil.rmtree('tests/datasets/cache/surface_meshes')
+
+
+def test_Combination():
+    dataset_params = {
+        'root': SHAPENET_ROOT,
+        'cache_dir': CACHE_DIR,
+        'categories': ['can'],
+        'train': True,
+        'split': .8,
+    }
+    # images = shapenet.ShapeNet_Images(root=SHAPENET_ROOT, cache_dir=CACHE_DIR, categories=['bowl'], views=1, train=True, split=.8)
+    meshes = shapenet.ShapeNet_Meshes(**dataset_params)
+    voxels = shapenet.ShapeNet_Voxels(**dataset_params, resolutions=[32])
+    sdf_points = shapenet.ShapeNet_SDF_Points(**dataset_params, smoothing_iterations=3, num_points=500, occ=False,
+                                              sample_box=True)
+
+    points = shapenet.ShapeNet_Points(**dataset_params, resolution=100, smoothing_iterations=3, num_points=500,
+                                      surface=False, normals=True)
+
+    dataset = shapenet.ShapeNet_Combination([voxels, sdf_points, points])
+
+    for obj in dataset:
+        obj_data = obj['data']
+        assert set(obj['data']['sdf_points'].shape) == set([500, 3])
+        assert set(obj['data']['sdf_distances'].shape) == set([500])
+        assert set(obj['data']['32'].shape) == set([32, 32, 32])
+        assert set(obj['data']['points'].shape) == set([500, 3])
+        assert set(obj['data']['normals'].shape) == set([500, 3])
+
+    train_loader = DataLoader(dataset, batch_size=2, shuffle=True, num_workers=8)
+    for batch in train_loader:
+        assert set(batch['data']['sdf_points'].shape) == set([2, 500, 3])
+        assert set(batch['data']['sdf_distances'].shape) == set([2, 500])
+        assert set(batch['data']['32'].shape) == set([2, 32, 32, 32])
+        assert set(batch['data']['points'].shape) == set([2, 500, 3])
+        assert set(batch['data']['normals'].shape) == set([2, 500, 3])
+
+    shutil.rmtree('tests/datasets/cache/sdf_points')
+    shutil.rmtree('tests/datasets/cache/points')
+    shutil.rmtree('tests/datasets/cache/voxels')
+    shutil.rmtree('tests/datasets/cache/surface_meshes')

--- a/tests/datasets/test_ShapeNet.py
+++ b/tests/datasets/test_ShapeNet.py
@@ -33,14 +33,14 @@ CACHE_DIR = 'tests/datasets/cache'
 
 
 def test_Meshes():
-    meshes1 = shapenet.ShapeNet_Meshes(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+    meshes1 = shapenet.ShapeNet_Meshes(root=SHAPENET_ROOT,
                                        categories=['can'], train=True, split=.7)
     assert len(meshes1) > 0
     for mesh in meshes1:
         assert Path(mesh['attributes']['path']).is_file()
         assert mesh['data']['vertices'].shape[0] > 0
 
-    meshes2 = shapenet.ShapeNet_Meshes(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+    meshes2 = shapenet.ShapeNet_Meshes(root=SHAPENET_ROOT,
                                        categories=['can', 'bowl'], train=True, split=.7)
     assert len(meshes2) > len(meshes1)
 
@@ -63,7 +63,8 @@ def test_Voxels():
 
 
 # def test_Images():
-#     images = shapenet.ShapeNet_Images(root=SHAPENET_ROOT, cache_dir=CACHE_DIR, categories=['phone'], views=1, train=True, split=.7)
+#     images = shapenet.ShapeNet_Images(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+#                                       categories=['phone'], views=1, train=True, split=.7)
 #     assert len(images) == 736
 #     for obj in images:
 #         assert set(obj['data']['images'].shape) == set([137, 137, 4])
@@ -74,8 +75,9 @@ def test_Voxels():
 
 def test_Surface_Meshes():
     surface_meshes = shapenet.ShapeNet_Surface_Meshes(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
-                                                      categories=['can'], train=True, split=.1, resolution=100,
-                                                      smoothing_iterations=3, mode='Tri')
+                                                      categories=['can'], train=True, split=.1,
+                                                      resolution=100, smoothing_iterations=3,
+                                                      mode='Tri')
     assert len(surface_meshes) == 10
     assert surface_meshes.cache_dir.exists()
     assert len(list(surface_meshes.cache_dir.rglob('*.npz'))) == 10
@@ -86,8 +88,9 @@ def test_Surface_Meshes():
     shutil.rmtree('tests/datasets/cache/surface_meshes')
 
     surface_meshes = shapenet.ShapeNet_Surface_Meshes(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
-                                                      categories=['can'], train=True, split=.1, resolution=100,
-                                                      smoothing_iterations=3, mode='Quad')
+                                                      categories=['can'], train=True, split=.1,
+                                                      resolution=100, smoothing_iterations=3,
+                                                      mode='Quad')
     assert len(surface_meshes) == 10
     assert surface_meshes.cache_dir.exists()
     assert len(list(surface_meshes.cache_dir.rglob('*.npz'))) == 10
@@ -165,18 +168,20 @@ def test_SDF_Points():
 def test_Combination():
     dataset_params = {
         'root': SHAPENET_ROOT,
-        'cache_dir': CACHE_DIR,
         'categories': ['can'],
         'train': True,
         'split': .8,
     }
-    # images = shapenet.ShapeNet_Images(root=SHAPENET_ROOT, cache_dir=CACHE_DIR, categories=['bowl'], views=1, train=True, split=.8)
+    # images = shapenet.ShapeNet_Images(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
+    #                                   categories=['bowl'], views=1, train=True, split=.8)
     meshes = shapenet.ShapeNet_Meshes(**dataset_params)
-    voxels = shapenet.ShapeNet_Voxels(**dataset_params, resolutions=[32])
-    sdf_points = shapenet.ShapeNet_SDF_Points(**dataset_params, smoothing_iterations=3, num_points=500, occ=False,
+    voxels = shapenet.ShapeNet_Voxels(**dataset_params, cache_dir=CACHE_DIR, resolutions=[32])
+    sdf_points = shapenet.ShapeNet_SDF_Points(**dataset_params, cache_dir=CACHE_DIR,
+                                              smoothing_iterations=3, num_points=500, occ=False,
                                               sample_box=True)
 
-    points = shapenet.ShapeNet_Points(**dataset_params, resolution=100, smoothing_iterations=3, num_points=500,
+    points = shapenet.ShapeNet_Points(**dataset_params, cache_dir=CACHE_DIR, resolution=100,
+                                      smoothing_iterations=3, num_points=500,
                                       surface=False, normals=True)
 
     dataset = shapenet.ShapeNet_Combination([voxels, sdf_points, points])


### PR DESCRIPTION
Ensure ShapeNet dataset works well when entire dataset is downloaded from source.

- Added cache-dir argument to allow users to specify where converted representations are cached.
- Adapted tests and added decorators to automatically skip tests if dataset is not found at default location.

**Tests**
OS: Ubuntu 18.04
CUDA: 10.1
GPU: RTX 2080Ti
Driver: 435.21

Tests run:
- `pytest tests/datasets/test_ShapeNet.py`