### PR TITLE
Fix ShapeNet_Images and its tests

### DIFF
--- a/kaolin/datasets/shapenet.py
+++ b/kaolin/datasets/shapenet.py
@@ -232,9 +232,8 @@ class ShapeNet_Images(data.Dataset):
         torch.Size([10, 4, 137, 137])
     """
 
-    def __init__(self, root: str, categories: list = ['chair'], train: bool = True,
-                 split: float = .7, views: int = 23, transform=None,
-                 no_progress: bool = False):
+    def __init__(self, root: str, categories: list=['chair'], train: bool=True,
+                 split: float=.7, views: int=24, transform=None):
         self.root = Path(root)
         self.synsets = _convert_categories(categories)
         self.labels = [synset_to_label[s] for s in self.synsets]
@@ -243,16 +242,15 @@ class ShapeNet_Images(data.Dataset):
         self.names = []
         self.synset_idx = []
 
-        shapenet_img_root = self.root / 'images'
         # check if images exist
-        if not shapenet_img_root.exists():
+        if not self.root.exists():
             raise ValueError('ShapeNet images were not found at location {0}.'.format(
-                str(shapenet_img_root)))
+                str(self.root)))
 
         # find all needed images
-        for i in tqdm(range(len(self.synsets)), disable=no_progress):
+        for i in range(len(self.synsets)):
             syn = self.synsets[i]
-            class_target = shapenet_img_root / syn
+            class_target = self.root / syn
             assert class_target.exists(), \
                 "ShapeNet class, {0}, is not found".format(syn)
 
@@ -274,7 +272,7 @@ class ShapeNet_Images(data.Dataset):
         """Returns the item at index idx. """
         data = dict()
         attributes = dict()
-        name = self.names[index]
+        img_name = self.names[index]
         view_num = random.randrange(0, self.views)
         # load and process image
         img = Image.open(str(img_name / f'rendering/{view_num:02}.png'))
@@ -288,7 +286,7 @@ class ShapeNet_Images(data.Dataset):
         # load and process camera parameters
         param_location = img_name / 'rendering/rendering_metadata.txt'
         azimuth, elevation, _, distance, _ = np.loadtxt(param_location)[view_num]
-        cam_params = kal.math.geometry.transformations.compute_camera_params(
+        cam_params = kal.mathutils.geometry.transformations.compute_camera_params(
             azimuth, elevation, distance)
 
         data['images'] = img
@@ -298,8 +296,8 @@ class ShapeNet_Images(data.Dataset):
         data['params']['azi'] = azimuth
         data['params']['elevation'] = elevation
         data['params']['distance'] = distance
-        attributes['name'] = name
-        attributes['synset'] = self.synsets[synset_idx]
+        attributes['name'] = img_name
+        attributes['synset'] = self.synsets[self.synset_idx[index]]
         attributes['label'] = self.labels[self.synset_idx[index]]
         return {'data': data, 'attributes': attributes}
 

--- a/tests/datasets/test_ShapeNet.py
+++ b/tests/datasets/test_ShapeNet.py
@@ -30,10 +30,11 @@ CACHE_DIR = 'tests/datasets/cache'
 
 
 # Tests below can only be run is a ShapeNet dataset is available
-REASON = 'ShapeNet not found at default location: {}'.format(SHAPENET_ROOT)
+SHAPENET_NOT_FOUND = 'ShapeNet not found at default location: {}'.format(SHAPENET_ROOT)
+SHAPENET_RENDERING_NOT_FOUND = 'ShapeNetRendering not found at default location: {}'.format(
+    SHAPENET_RENDERING_ROOT)
 
-
-@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)
+@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=SHAPENET_NOT_FOUND)
 def test_Meshes():
     meshes1 = shapenet.ShapeNet_Meshes(root=SHAPENET_ROOT,
                                        categories=['can'], train=True, split=.7)
@@ -47,7 +48,7 @@ def test_Meshes():
     assert len(meshes2) > len(meshes1)
 
 
-@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)
+@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=SHAPENET_NOT_FOUND)
 def test_Voxels():
     voxels = shapenet.ShapeNet_Voxels(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
                                       categories=['can'], train=True, split=.7, resolutions=[32])
@@ -67,7 +68,8 @@ def test_Voxels():
 @pytest.mark.parametrize('categories', [['chair'], ['plane', 'bench', 'cabinet', 'car', 'chair',
                                                     'monitor', 'lamp', 'speaker', 'rifle',
                                                     'sofa', 'table', 'phone', 'watercraft']])
-@pytest.mark.skipif(not Path(SHAPENET_RENDERING_ROOT).exists(), reason=REASON)
+@pytest.mark.skipif(not Path(SHAPENET_RENDERING_ROOT).exists(),
+                    reason=SHAPENET_RENDERING_NOT_FOUND)
 def test_Images(categories):
     images = shapenet.ShapeNet_Images(root=SHAPENET_RENDERING_ROOT,
                                       categories=categories, views=24, train=True, split=.7)
@@ -81,7 +83,7 @@ def test_Images(categories):
         assert list(obj['data']['params']['cam_mat'].shape) == [3, 3]
         assert list(obj['data']['params']['cam_pos'].shape) == [3]
 
-@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)
+@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=SHAPENET_NOT_FOUND)
 def test_Surface_Meshes():
     surface_meshes = shapenet.ShapeNet_Surface_Meshes(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
                                                       categories=['can'], train=True, split=.1,
@@ -110,7 +112,7 @@ def test_Surface_Meshes():
     shutil.rmtree('tests/datasets/cache/surface_meshes')
 
 
-@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)
+@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=SHAPENET_NOT_FOUND)
 def test_Points():
     points = shapenet.ShapeNet_Points(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
                                       categories=['can'], train=True, split=.1,
@@ -143,7 +145,7 @@ def test_Points():
     shutil.rmtree('tests/datasets/cache/surface_meshes')
 
 
-@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)
+@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=SHAPENET_NOT_FOUND)
 def test_SDF_Points():
     sdf_points = shapenet.ShapeNet_SDF_Points(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
                                               categories=['can'], train=True, split=.1,
@@ -176,7 +178,7 @@ def test_SDF_Points():
     shutil.rmtree('tests/datasets/cache/surface_meshes')
 
 
-@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)
+@pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=SHAPENET_NOT_FOUND)
 def test_Combination():
     dataset_params = {
         'root': SHAPENET_ROOT,

--- a/tests/datasets/test_ShapeNet.py
+++ b/tests/datasets/test_ShapeNet.py
@@ -24,7 +24,8 @@ from torch.utils.data import DataLoader
 from kaolin.datasets import shapenet
 
 
-SHAPENET_ROOT = 'data/ShapeNet/'
+SHAPENET_ROOT = '/data/ShapeNet/'
+SHAPENET_RENDERING_ROOT = '/data/ShapeNetRendering'
 CACHE_DIR = 'tests/datasets/cache'
 
 
@@ -63,17 +64,22 @@ def test_Voxels():
 
     shutil.rmtree('tests/datasets/cache/voxels')
 
-
-# def test_Images():
-#     images = shapenet.ShapeNet_Images(root=SHAPENET_ROOT, cache_dir=CACHE_DIR,
-#                                       categories=['phone'], views=1, train=True, split=.7)
-#     assert len(images) == 736
-#     for obj in images:
-#         assert set(obj['data']['images'].shape) == set([137, 137, 4])
-#         assert os.path.isfile(obj['attributes']['name'] + '/rendering/00.png')
-#         assert set(obj['data']['params']['cam_mat'].shape) == set([3, 3])
-#         assert set(obj['data']['params']['cam_pos'].shape) == set([3])
-
+@pytest.mark.parametrize('categories', [['chair'], ['plane', 'bench', 'cabinet', 'car', 'chair',
+                                                    'monitor', 'lamp', 'speaker', 'rifle',
+                                                    'sofa', 'table', 'phone', 'watercraft']])
+@pytest.mark.skipif(not Path(SHAPENET_RENDERING_ROOT).exists(), reason=REASON)
+def test_Images(categories):
+    images = shapenet.ShapeNet_Images(root=SHAPENET_RENDERING_ROOT,
+                                      categories=categories, views=24, train=True, split=.7)
+    if categories == ['chair']:
+        assert len(images) == 4744
+    else:
+        assert len(images) == 30644
+    for obj in images:
+        assert list(obj['data']['images'].shape) == [4, 137, 137]
+        assert os.path.isfile(obj['attributes']['name'] / 'rendering/00.png')
+        assert list(obj['data']['params']['cam_mat'].shape) == [3, 3]
+        assert list(obj['data']['params']['cam_pos'].shape) == [3]
 
 @pytest.mark.skipif(not Path(SHAPENET_ROOT).exists(), reason=REASON)
 def test_Surface_Meshes():


### PR DESCRIPTION
### Description
- Fix ShapeNet_Images to follower original ShapeNetRendering topology.
- put back tests/datasets/test_ShapeNet.py:test_Images and fixed it.

### Tests
Tested with `pytest test_ShapeNet.py`
OS: Ubuntu 18.04
GPU: Titan RTX
CUDA: 10.2
Driver: 440.31

### Comments
There are still some fix to be done on ShapeNet_Images, among them:
- Remove the non-determinism due to random view selection in `getitem`
- Tougher tests
- Format fixes

