### PR TITLE
Setup readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+
+python:
+   version: 3.7
+   system_packages: true
+   install:
+      - requirements: docs/requirements.txt
+      - method: setuptools
+        path: '.'

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-   version: 3.7
+   version: 3.6
    system_packages: true
    install:
       - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,16 @@
 
 import os
 import sys
+
+
+# Get version number
+version_path = os.path.join('../', 'kaolin', 'version.py')
+with open(version_path, 'r') as f:
+    for row in f:
+        if '__version__' in row:
+            kal_version = row.split("'")[-2]
+            break
+
 sys.path.append('../')
 sys.path.append(os.path.abspath(os.path.join(
     os.path.dirname(__file__), '..', 'kaolin')))
@@ -25,10 +35,10 @@ master_doc = 'index'
 
 project = 'kaolin'
 copyright = '2019, NVIDIA Development Inc.'
-author = 'Krishna Murthy, Edward Smith, Wenzheng Chen, Amlan Kar, Jun Gao, Huan Ling, Clement Fuji Tsang, Ankur Handa, Sanja Fidler'
-
+author = 'NVIDIA'
+version = kal_version
 # The full version, including alpha/beta/rc tags
-release = '0.1.0 alpha'
+release = kal_version
 
 
 # -- General configuration ---------------------------------------------------
@@ -47,6 +57,16 @@ extensions = [
 ]
 
 napoleon_use_ivar = True
+
+# Mock CUDA Imports
+autodoc_mock_imports = ['kaolin.cuda.ball_query',
+                        'kaolin.cuda.load_textures',
+                        'kaolin.cuda.sided_distance',
+                        'kaolin.cuda.furthest_point_sampling',
+                        'kaolin.cuda.three_nn',
+                        'kaolin.cuda.tri_distance',
+                        'kaolin.cuda.mesh_intersection',
+                        'kaolin.graphics.nmr.cuda.rasterize_cuda']
 
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,8 +15,7 @@ import sys
 
 
 # Get version number
-version_path = os.path.join('../', 'kaolin', 'version.py')
-with open(version_path, 'r') as f:
+with open('../kaolin/version.py', 'r') as f:
     for row in f:
         if '__version__' in row:
             kal_version = row.split("'")[-2]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
--f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-numpy
-torch_nightly
+-f https://download.pytorch.org/whl/cpu/torch-1.3.1%2Bcpu-cp36-cp36m-linux_x86_64.whl
+-f https://download.pytorch.org/whl/cpu/torchvision-0.4.2%2Bcpu-cp36-cp36m-linux_x86_64.whl
+torch
 sphinx
 Cython
 torchvision

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+-f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+numpy
+torch_nightly
+sphinx
+Cython
+torchvision

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
     )
 
     import torch
-    from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+    from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CUDA_HOME
     import Cython
     from Cython.Build import cythonize
     import numpy as np
@@ -136,43 +136,47 @@ if __name__ == '__main__':
     )
 
     ext_modules = [
-        CUDAExtension('kaolin.cuda.load_textures', [
-            'kaolin/cuda/load_textures_cuda.cpp',
-            'kaolin/cuda/load_textures_cuda_kernel.cu',
-        ]),
-        CUDAExtension('kaolin.cuda.sided_distance', [
-            'kaolin/cuda/sided_distance.cpp',
-            'kaolin/cuda/sided_distance_cuda.cu',
-        ]),
-        CUDAExtension('kaolin.cuda.furthest_point_sampling', [
-            'kaolin/cuda/furthest_point_sampling.cpp',
-            'kaolin/cuda/furthest_point_sampling_cuda.cu',
-        ]),
-        CUDAExtension('kaolin.cuda.ball_query', [
-            'kaolin/cuda/ball_query.cpp',
-            'kaolin/cuda/ball_query_cuda.cu',
-        ]),
-        CUDAExtension('kaolin.cuda.three_nn', [
-            'kaolin/cuda/three_nn.cpp',
-            'kaolin/cuda/three_nn_cuda.cu',
-        ]),
-        CUDAExtension('kaolin.cuda.tri_distance', [
-            'kaolin/cuda/triangle_distance.cpp',
-            'kaolin/cuda/triangle_distance_cuda.cu',
-        ]),
-        CUDAExtension('kaolin.cuda.mesh_intersection', [
-            'kaolin/cuda/mesh_intersection.cpp',
-            'kaolin/cuda/mesh_intersection_cuda.cu',
-        ]),
-        CUDAExtension('kaolin.graphics.nmr.cuda.rasterize_cuda', [
-            'kaolin/graphics/nmr/cuda/rasterize_cuda.cpp',
-            'kaolin/graphics/nmr/cuda/rasterize_cuda_kernel.cu',
-        ]),
         triangle_hash_module,
         mise_module,
         mcubes_module,
         nnsearch_module,
     ]
+    
+    # If building with readthedocs, don't compile CUDA extensions
+    if os.getenv('READTHEDOCS') != 'True':
+        ext_modules += [
+            CUDAExtension('kaolin.cuda.load_textures', [
+                'kaolin/cuda/load_textures_cuda.cpp',
+                'kaolin/cuda/load_textures_cuda_kernel.cu',
+            ]),
+            CUDAExtension('kaolin.cuda.sided_distance', [
+                'kaolin/cuda/sided_distance.cpp',
+                'kaolin/cuda/sided_distance_cuda.cu',
+            ]),
+            CUDAExtension('kaolin.cuda.furthest_point_sampling', [
+                'kaolin/cuda/furthest_point_sampling.cpp',
+                'kaolin/cuda/furthest_point_sampling_cuda.cu',
+            ]),
+            CUDAExtension('kaolin.cuda.ball_query', [
+                'kaolin/cuda/ball_query.cpp',
+                'kaolin/cuda/ball_query_cuda.cu',
+            ]),
+            CUDAExtension('kaolin.cuda.three_nn', [
+                'kaolin/cuda/three_nn.cpp',
+                'kaolin/cuda/three_nn_cuda.cu',
+            ]),
+            CUDAExtension('kaolin.cuda.tri_distance', [
+                'kaolin/cuda/triangle_distance.cpp',
+                'kaolin/cuda/triangle_distance_cuda.cu',
+            ]),
+            CUDAExtension('kaolin.cuda.mesh_intersection', [
+                'kaolin/cuda/mesh_intersection.cpp',
+                'kaolin/cuda/mesh_intersection_cuda.cu',
+            ]),
+            CUDAExtension('kaolin.graphics.nmr.cuda.rasterize_cuda', [
+                'kaolin/graphics/nmr/cuda/rasterize_cuda.cpp',
+                'kaolin/graphics/nmr/cuda/rasterize_cuda_kernel.cu',
+            ])]
 
     setup(
         # Metadata

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
     )
 
     import torch
-    from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CUDA_HOME
+    from torch.utils.cpp_extension import BuildExtension, CUDAExtension
     import Cython
     from Cython.Build import cythonize
     import numpy as np

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ requirements = [
     'shapely',
     'trimesh>=3.0',
     'scipy',
-    'sphinx',
+    'sphinx==2.2.0',    # pinned to resolve issue with docutils 0.16b0.dev
     # 'sphinx_rtd_theme',
     'pytest>=4.6',
     'pytest-cov>=2.7',


### PR DESCRIPTION
### Description
Add support for readthedocs documentation builds

### Tests
OS: Ubuntu 18.04
Driver: 440.36
CUDA: 10.2
Python 3.6

Readthedocs - Confirmed documentations are successfully built from fork branch.

Commands:
- pytest tests/