### PR TITLE
Increase minimum PyTorch requirements to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ Kaolin curates a large _model zoo_ containing reference implementations of popul
 ### Requirements
 - Linux
 - Python >= 3.6
-- CUDA-enabled machine (i.e. with `nvcc` installed)
+- CUDA >= 10.0.130 (with `nvcc` installed)
+- Display Driver >= 410.48
 
 Windows support is in the works and is currently considered experimental.
 
 ### Dependencies
 - numpy >= 1.17
-- PyTorch >= 1.0 and Torchvision (see [pytorch.org](http://pytorch.org) for installation instructions)
+- PyTorch >= 1.2 and Torchvision (see [pytorch.org](http://pytorch.org) for installation instructions)
 
 ### Installation
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ logging.basicConfig(format='%(levelname)s - %(message)s')
 # Check that PyTorch version installed meets minimum requirements
 if torch.__version__ < '1.2.0':
     logger.warning(f'Kaolin is tested with PyTorch >= 1.2.0. Found version {torch.__version__} instead.')
-    # warnings.warn(f'Kaolin is tested with PyTorch >= 1.2.0. Found version {torch.__version__} instead.')
+
 
 # Get version number from version.py
 version = {}

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import io
+import torch
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CppExtension
 from setuptools import setup, find_packages
 import numpy as np
@@ -25,6 +26,10 @@ metrics for seamless evaluation and provides visualization functionality to rend
 a comprehensive model zoo comprising many state-of-the-art 3D deep learning architectures, to serve as a starting point
 for future research endeavours.
 """
+
+
+# Check that PyTorch version installed meets minimum requirements
+assert torch.__version__ >= '1.2.0', f'Kaolin requires PyTorch >= 1.2.0. Found version {torch.__version__} instead.'
 
 
 # Get version number from version.py

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 import os
 import io
+import logging
+from setuptools import setup, find_packages
+
 import torch
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CppExtension
-from setuptools import setup, find_packages
 import numpy as np
 
 
@@ -28,9 +30,14 @@ for future research endeavours.
 """
 
 
-# Check that PyTorch version installed meets minimum requirements
-assert torch.__version__ >= '1.2.0', f'Kaolin requires PyTorch >= 1.2.0. Found version {torch.__version__} instead.'
+logger = logging.getLogger()
+logging.basicConfig(format='%(levelname)s - %(message)s')
 
+
+# Check that PyTorch version installed meets minimum requirements
+if torch.__version__ < '1.2.0':
+    logger.warning(f'Kaolin is tested with PyTorch >= 1.2.0. Found version {torch.__version__} instead.')
+    # warnings.warn(f'Kaolin is tested with PyTorch >= 1.2.0. Found version {torch.__version__} instead.')
 
 # Get version number from version.py
 version = {}


### PR DESCRIPTION
### Description
- Increase minimum PyTorch requirements to 1.2.0
- Add minimum requirement for CUDA to 10.0.130
- Add minimum display driver version to 410.48 (minimum version for CUDA 10.0.130)
- Add minimum PyTorch version assert in setup.py

### Related Issues
#65 

### Testing PyTorch versions (before changes)
#### PyTorch 0.4.1, CUDA 9
- Docker Container: `pytorch/pytorch:0.4.1-cuda9-cudnn7-devel`
    - python setup.py develop (`fatal error: torch/extension.h: No such file or directory`)
#### PyTorch 1.0, CUDA 10.0
- Docker Container: `pytorch/pytorch:1.0-cuda10.0-cudnn7-devel`
    - python setup.py develop (`error: 'TORCH_CHECK' was not declared in this scope`)
#### PyTorch 1.1.0, CUDA 10.0
- Docker Container: `pytorch/pytorch:1.1.0-cuda10.0-cudnn7.5-devel`
    - python setup.py develop (`error: 'TORCH_CHECK' was not declared in this scope`)
#### PyTorch 1.2, CUDA 9.2
- Docker Container: `nvidia/cuda:9.2-base-ubuntu16.04`
    - pip install torch==1.2.0+cu92 torchvision==0.4.0+cu92 -f https://download.pytorch.org/whl/torch_stable.html
    - python setup.py develop (`error: command '/usr/local/cuda/bin/nvcc' failed with exit status 1`)
#### PyTorch 1.2, CUDA 10.0
- Docker Container: `pytorch/pytorch:1.2-cuda10.0-cudnn7-devel`
    - python setup.py develop (successful build)

### Tests (after changes)
- Docker Container: `pytorch/pytorch:1.2-cuda10.0-cudnn7-devel`
    - python setup.py develop (successful build)
- Docker Container: `pytorch/pytorch:1.0.1-cuda10.0-cudnn7-devel`
    - python setup.py develop (Warning logged)