### PR TITLE
Cache using pickle

### DIFF
--- a/tests/datasets/test_ShapeNet.py
+++ b/tests/datasets/test_ShapeNet.py
@@ -79,7 +79,7 @@ def test_Images(categories):
         assert len(images) == 30644
     for obj in images:
         assert list(obj['data']['images'].shape) == [4, 137, 137]
-        assert os.path.isfile(obj['attributes']['name'] / 'rendering/00.png')
+        assert (Path(obj['attributes']['name']) / 'rendering/00.png').is_file()
         assert list(obj['data']['params']['cam_mat'].shape) == [3, 3]
         assert list(obj['data']['params']['cam_pos'].shape) == [3]
 
@@ -91,7 +91,7 @@ def test_Surface_Meshes():
                                                       mode='Tri')
     assert len(surface_meshes) == 10
     assert surface_meshes.cache_dir.exists()
-    assert len(list(surface_meshes.cache_dir.rglob('*.npz'))) == 10
+    assert len(list(surface_meshes.cache_dir.rglob('*.p'))) == 10
     for smesh in surface_meshes:
         assert smesh['data']['vertices'].shape[0] > 0
         assert smesh['data']['faces'].shape[1] == 3
@@ -104,7 +104,7 @@ def test_Surface_Meshes():
                                                       mode='Quad')
     assert len(surface_meshes) == 10
     assert surface_meshes.cache_dir.exists()
-    assert len(list(surface_meshes.cache_dir.rglob('*.npz'))) == 10
+    assert len(list(surface_meshes.cache_dir.rglob('*.p'))) == 10
     for smesh in surface_meshes:
         assert smesh['data']['vertices'].shape[0] > 0
         assert smesh['data']['faces'].shape[1] == 4
@@ -121,7 +121,7 @@ def test_Points():
 
     assert len(points) == 10
     assert points.cache_dir.exists()
-    assert len(list(points.cache_dir.rglob('*.npz'))) == 10
+    assert len(list(points.cache_dir.rglob('*.p'))) == 10
     for obj in points:
         assert set(obj['data']['points'].shape) == set([5000, 3])
         assert set(obj['data']['normals'].shape) == set([5000, 3])
@@ -135,7 +135,7 @@ def test_Points():
 
     assert len(points) == 10
     assert points.cache_dir.exists()
-    assert len(list(points.cache_dir.rglob('*.npz'))) == 10
+    assert len(list(points.cache_dir.rglob('*.p'))) == 10
     for obj in points:
         assert set(obj['data']['points'].shape) == set([5000, 3])
         assert set(obj['data']['normals'].shape) == set([5000, 3])
@@ -154,7 +154,7 @@ def test_SDF_Points():
 
     assert len(sdf_points) == 10
     assert sdf_points.cache_dir.exists()
-    assert len(list(sdf_points.cache_dir.rglob('*.npz'))) == 10
+    assert len(list(sdf_points.cache_dir.rglob('*.p'))) == 10
     for obj in sdf_points:
         assert set(obj['data']['sdf_points'].shape) == set([5000, 3])
         assert set(obj['data']['sdf_distances'].shape) == set([5000])
@@ -168,7 +168,7 @@ def test_SDF_Points():
 
     assert len(sdf_points) == 10
     assert sdf_points.cache_dir.exists()
-    assert len(list(sdf_points.cache_dir.rglob('*.npz'))) == 10
+    assert len(list(sdf_points.cache_dir.rglob('*.p'))) == 10
     for obj in sdf_points:
         assert set(obj['data']['occ_points'].shape) == set([5000, 3])
         assert set(obj['data']['occ_values'].shape) == set([5000])

--- a/tests/datasets/test_usdfile.py
+++ b/tests/datasets/test_usdfile.py
@@ -26,7 +26,7 @@ def test_usd_meshes():
     assert len(usd_dataset) == 1
 
     # test caching
-    assert len(list(Path(cache_dir).glob('**/*.npz'))) == 1
+    assert len(list(Path(cache_dir).glob('**/*.p'))) == 1
     shutil.rmtree('tests/datasets_eval/USDMeshes')
 
 # Tests below must be run with KitchenSet dataset

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,99 @@
+import os
+import shutil
+
+import pytest
+import torch
+import numpy as np
+
+import kaolin as kal
+from kaolin import helpers
+
+
+CACHE_DIR = 'tests/cache'
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    """Cleanup after each test. """
+    yield
+    shutil.rmtree(CACHE_DIR)
+
+
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_cache_tensor(device):
+    tensor = torch.ones(5, device=device)
+
+    cache = helpers.Cache(func=lambda x: x, cache_dir=CACHE_DIR, cache_key='test')
+    cache('tensor', x=tensor)
+
+    # Make sure cache is created
+    assert os.path.exists(os.path.join(CACHE_DIR, 'test', 'tensor.p'))
+
+    # Confirm loaded tensor is correct and on CPU device
+    loaded = cache('tensor')
+    assert torch.all(loaded.eq(tensor.cpu()))
+
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_cache_dict(device):
+    dictionary = {
+        'a': torch.ones(5, device=device),
+        'b': np.zeros(5),
+    }
+
+    cache = helpers.Cache(func=lambda x: x, cache_dir=CACHE_DIR, cache_key='test')
+    cache('dictionary', x=dictionary)
+
+    # Make sure cache is created
+    assert os.path.exists(os.path.join(CACHE_DIR, 'test', 'dictionary.p'))
+
+    # Confirm loaded dict is correct and on CPU device
+    loaded = cache('dictionary')
+    assert torch.all(loaded['a'].eq(dictionary['a'].cpu()))
+    assert np.all(np.isclose(loaded['b'], dictionary['b']))
+
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_cache_mesh(device):
+    vertices = torch.ones(10, 3, device=device)
+    faces = torch.ones(20, 3, device=device, dtype=torch.long)
+    mesh = kal.rep.TriangleMesh.from_tensors(vertices, faces)
+
+    cache = helpers.Cache(func=lambda x: x, cache_dir=CACHE_DIR, cache_key='test')
+    cache('mesh', x=mesh)
+
+    # Make sure cache is created
+    assert os.path.exists(os.path.join(CACHE_DIR, 'test', 'mesh.p'))
+
+    # Confirm loaded mesh is correct and on CPU device
+    loaded = cache('mesh')
+    assert torch.all(loaded.vertices.eq(vertices.cpu()))
+    assert torch.all(loaded.faces.eq(faces.cpu()))
+
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_cache_voxelgrid(device):
+    voxels = torch.ones(3, 3, 3, device=device)
+    voxelgrid = kal.rep.VoxelGrid(voxels)
+
+    cache = helpers.Cache(func=lambda x: x, cache_dir=CACHE_DIR, cache_key='test')
+    cache('voxelgrid', x=voxelgrid)
+
+    # Make sure cache is created
+    assert os.path.exists(os.path.join(CACHE_DIR, 'test', 'voxelgrid.p'))
+
+    # Confirm loaded voxelgrid is correct and on CPU device
+    loaded = cache('voxelgrid')
+    assert torch.all(loaded.voxels.eq(voxels.cpu()))
+
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_cache_pointcloud(device):
+    points = torch.ones(10, 3, device=device)
+    pointcloud = kal.rep.PointCloud(points)
+
+    cache = helpers.Cache(func=lambda x: x, cache_dir=CACHE_DIR, cache_key='test')
+    cache('pointcloud', x=pointcloud)
+
+    # Make sure cache is created
+    assert os.path.exists(os.path.join(CACHE_DIR, 'test', 'pointcloud.p'))
+
+    # Confirm loaded pointcloud is correct and on CPU device
+    loaded = cache('pointcloud')
+    assert torch.all(loaded.points.eq(points.cpu()))


### PR DESCRIPTION
### Description
Use Pytorch pickle functionality to cache data. In testing on caching tensors, pickling was 37.5% faster in write performance and 83.6% faster in read performance compared with the previous numpy caching function. Pickling also enables caching class instances such as PointClouds, VoxelGrids and Meshes.

### Code Origin
Code changes originate entirely from me.

### Tests
- **OS:** Ubuntu 18.04
- **GPU:** RTX 2080Ti
- **Driver:** 440.44
- **CUDA:** 10.2


#### Commands:
- pytest tests/


Signed-off-by: Jean-Francois Lafleche <jlafleche@nvidia.com>