### PR TITLE
Vertex coordinate fix for obj loader

### DIFF
--- a/kaolin/rep/Mesh.py
+++ b/kaolin/rep/Mesh.py
@@ -148,7 +148,7 @@ class Mesh():
                 if data[0] == 'v':
                     vertices.append(data[1:])
                 elif data[0] == 'vt':
-                    uvs.append(data[1:])
+                    uvs.append(data[1:3])
                 elif data[0] == 'f':
                     if '//' in data[1]:
                         data = [da.split('//') for da in data]


### PR DESCRIPTION
Although I'm assuming Kaolin's obj loader (in kaolin.rep.Mesh.from_obj) only supports 2D textures, some obj files with 2D textures still include a zeroed-out 3rd dimension for the vertex texture coordinates. To support these files, I added a simple fix to set the extent of the slice. 

All tests passed but tests requiring ModelNet and ShapeNet were skipped.

Signed-off-by: tovacinni <tovacinni@gmail.com>

