### PR TITLE
Add softras examples

### DIFF
--- a/examples/renderers/softras_simple_render.py
+++ b/examples/renderers/softras_simple_render.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/renderers/softras_simple_render.py
+++ b/examples/renderers/softras_simple_render.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Soft Rasterizer (SoftRas)
+#
+# Copyright (c) 2017 Hiroharu Kato
+# Copyright (c) 2018 Nikos Kolotouros
+# Copyright (c) 2019 Shichen Liu
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import torch
+import kaolin
+import matplotlib.pyplot as plt
+
+# Example script that uses SoftRas to render an image, given a mesh input
+
+if __name__ == "__main__":
+
+    # Initialize the soft rasterizer.
+    renderer = kaolin.graphics.SoftRenderer(camera_mode="look_at", device="cuda:0")
+
+    # Read in the input mesh.
+    filename_input = "tests/model.obj"
+    mesh = kaolin.rep.TriangleMesh.from_obj(filename_input)
+
+    # Extract the vertices, faces, and texture the mesh (currently color with white).
+    vertices = mesh.vertices.float()
+    faces = mesh.faces.long()
+    face_textures = faces.clone()
+    vertices = vertices[None, :, :].cuda()
+    faces = faces[None, :, :].cuda()
+    face_textures = face_textures[None, :, :].cuda()
+    textures = torch.ones(1, faces.shape[1], 2, 3, dtype=torch.float32).cuda()
+
+    # Render an image.
+    rgb, d, _, = renderer.forward(vertices, faces, textures)
+
+    # Display.
+    plt.imshow(rgb[0].permute(1, 2, 0).cpu().numpy())
+    plt.show()

--- a/examples/renderers/softras_simple_render.py
+++ b/examples/renderers/softras_simple_render.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/renderers/softras_texture_optimization.py
+++ b/examples/renderers/softras_texture_optimization.py
@@ -38,7 +38,6 @@
 # SOFTWARE.
 
 import imageio
-import matplotlib.pyplot as plt
 import torch
 
 import kaolin

--- a/examples/renderers/softras_texture_optimization.py
+++ b/examples/renderers/softras_texture_optimization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/renderers/softras_texture_optimization.py
+++ b/examples/renderers/softras_texture_optimization.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Soft Rasterizer (SoftRas)
+#
+# Copyright (c) 2017 Hiroharu Kato
+# Copyright (c) 2018 Nikos Kolotouros
+# Copyright (c) 2019 Shichen Liu
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import imageio
+import matplotlib.pyplot as plt
+import torch
+
+import kaolin
+
+# Example script that uses SoftRas to render an image, given a mesh input
+
+
+class Model(nn.Module):
+    """Wrap textures into an nn.Module, for optimization. """
+
+    def __init__(self, textures):
+        super(Model, self).__init__()
+        self.textures = textures
+
+    def forward(self):
+        return torch.sigmoid(self.textures)
+
+
+if __name__ == "__main__":
+
+    # Initialize the soft rasterizer.
+    renderer = kaolin.graphics.SoftRenderer(camera_mode="look_at", device="cuda:0")
+
+    # Read in the input mesh. TODO: Add filepath as argument.
+    mesh = kaolin.rep.TriangleMesh.from_obj("tests/model.obj")
+
+    # Extract the vertices, faces, and texture the mesh (currently color with white).
+    vertices = mesh.vertices.float()
+    faces = mesh.faces.long()
+    face_textures = faces.clone()
+    vertices = vertices[None, :, :].cuda()
+    faces = faces[None, :, :].cuda()
+    face_textures = face_textures[None, :, :].cuda()
+    textures = torch.ones(1, faces.shape[1], 2, 3, dtype=torch.float32).cuda()
+
+    # TODO: Normalize vertices (Use kaolin functionality to do this)
+    vertices = vertices - 0.5 * (vertices.max() - vertices.min())
+    # Scale the mesh to a "reasonable" size (TODO: avoid this "magic" number)
+    vertices = 5 * vertices
+
+    # TODO: Fix path. Add obj to kaolin.
+    mesh_target = kaolin.rep.TriangleMesh.from_obj("data/banana.obj")
+    # TODO: Fix path
+    img_target = torch.from_numpy(
+        imageio.imread("data/target.png").astype(np.float32).mean(-1) / 255
+    )[None, ::].cuda()
+
+    # Create a 'model' (an nn.Module) that wraps around the vertices, making it 'optimizable'.
+    # TODO: Replace with a torch optimizer that takes vertices as a 'params' argument.
+    # Deform the vertices slightly.
+    model = Model(textures).cuda()
+    # renderer.transform.set_eyes_from_angles(camera_distance, elevation, azimuth)
+    optimizer = torch.optim.Adam(model.parameters(), 0.001, betas=(0.5, 0.99))
+    mseloss = torch.nn.MSELoss()
+
+    # Perform vertex optimization.
+    for i in tqdm.tqdm(2000):
+        optimizer.zero_grad()
+        textures = model()
+        rgb, _, _ = renderer(vertices, faces, new_textures)
+        loss = mseloss(rgb, img_target[None, :, :])
+        loss.backward()
+        optimizer.step()
+        if i % 20 == 0:
+            # TODO: Add functionality to write to gif output file.
+            tqdm.write("Loss: " + str(loss.item()) + "\n")

--- a/examples/renderers/softras_texture_optimization.py
+++ b/examples/renderers/softras_texture_optimization.py
@@ -38,6 +38,7 @@
 # SOFTWARE.
 
 import imageio
+import matplotlib.pyplot as plt
 import torch
 
 import kaolin

--- a/examples/renderers/softras_texture_optimization.py
+++ b/examples/renderers/softras_texture_optimization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/renderers/softras_vertex_optimization.py
+++ b/examples/renderers/softras_vertex_optimization.py
@@ -38,7 +38,6 @@
 # SOFTWARE.
 
 import imageio
-import matplotlib.pyplot as plt
 import torch
 
 import kaolin

--- a/examples/renderers/softras_vertex_optimization.py
+++ b/examples/renderers/softras_vertex_optimization.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Soft Rasterizer (SoftRas)
+#
+# Copyright (c) 2017 Hiroharu Kato
+# Copyright (c) 2018 Nikos Kolotouros
+# Copyright (c) 2019 Shichen Liu
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import imageio
+import matplotlib.pyplot as plt
+import torch
+
+import kaolin
+
+# Example script that uses SoftRas to render an image, given a mesh input
+
+
+class Model(nn.Module):
+    """Wrap vertices into an nn.Module, for optimization. """
+
+    def __init__(self, vertices):
+        super(Model, self).__init__()
+        self.update = nn.Parameter(torch.rand(vertices.shape) * 0.001)
+        self.verts = vertices
+
+    def forward(self):
+        return self.update + self.verts
+
+
+if __name__ == "__main__":
+
+    # Initialize the soft rasterizer.
+    renderer = kaolin.graphics.SoftRenderer(camera_mode="look_at", device="cuda:0")
+
+    # Read in the input mesh. TODO: Add filepath as argument.
+    mesh = kaolin.rep.TriangleMesh.from_obj("tests/model.obj")
+
+    # Extract the vertices, faces, and texture the mesh (currently color with white).
+    vertices = mesh.vertices.float()
+    faces = mesh.faces.long()
+    face_textures = faces.clone()
+    vertices = vertices[None, :, :].cuda()
+    faces = faces[None, :, :].cuda()
+    face_textures = face_textures[None, :, :].cuda()
+    textures = torch.ones(1, faces.shape[1], 2, 3, dtype=torch.float32).cuda()
+
+    # TODO: Normalize vertices (Use kaolin functionality to do this)
+    vertices = vertices - 0.5 * (vertices.max() - vertices.min())
+    # Scale the mesh to a "reasonable" size (TODO: avoid this "magic" number)
+    vertices = 5 * vertices
+
+    # TODO: Fix path. Add obj to kaolin.
+    mesh_target = kaolin.rep.TriangleMesh.from_obj("data/banana.obj")
+    # TODO: Fix path
+    img_target = torch.from_numpy(
+        imageio.imread("data/target.png").astype(np.float32).mean(-1) / 255
+    )[None, ::].cuda()
+
+    # Create a 'model' (an nn.Module) that wraps around the vertices, making it 'optimizable'.
+    # TODO: Replace with a torch optimizer that takes vertices as a 'params' argument.
+    # Deform the vertices slightly.
+    model = Model(vertices.clone()).cuda()
+    renderer.transform.set_eyes_from_angles(camera_distance, elevation, azimuth)
+    optimizer = torch.optim.Adam(model.parameters(), 0.001, betas=(0.5, 0.99))
+    mseloss = torch.nn.MSELoss()
+
+    # Perform vertex optimization.
+    for i in tqdm.tqdm(2000):
+        optimizer.zero_grad()
+        new_vertices = model()
+        rgb, _, _ = renderer(new_vertices, faces, textures)
+        loss = mseloss(rgb, img_target[None, :, :])
+        loss.backward()
+        optimizer.step()
+        if i % 20 == 0:
+            # TODO: Add functionality to write to gif output file.
+            tqdm.write("Loss: " + str(loss.item()) + "\n")

--- a/examples/renderers/softras_vertex_optimization.py
+++ b/examples/renderers/softras_vertex_optimization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/renderers/softras_vertex_optimization.py
+++ b/examples/renderers/softras_vertex_optimization.py
@@ -38,6 +38,7 @@
 # SOFTWARE.
 
 import imageio
+import matplotlib.pyplot as plt
 import torch
 
 import kaolin

--- a/examples/renderers/softras_vertex_optimization.py
+++ b/examples/renderers/softras_vertex_optimization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Add examples to demonstrate usage of the new softras core module.

1. `softras_simple_render.py`: Simple RGB image rendering
2. `softras_vertex_optimization.py`: Vertex optimization using softras
3. `softras_texture_optimization.py`: Texture optimization using softras

Examples functional. Minor TODOs remain.
* Add `argparse` to all examples.
* Clean up paths, filenames.
* Wrap `vertices` and `textures` directly into a `torch.optim.Adam` object, instead of creating an `nn.Module`.
* Write output to `.gif` file.

Signed-off-by: Krishna Murthy <krrish94@gmail.com>