### PR TITLE
Fix/msvc compilation

### DIFF
--- a/examples/renderers/NMR/neural_renderer/cuda/rasterize_cuda_kernel.cu
+++ b/examples/renderers/NMR/neural_renderer/cuda/rasterize_cuda_kernel.cu
@@ -29,7 +29,7 @@
 #include <cuda_runtime.h>
 
 // for the older gpus atomicAdd with double arguments does not exist
-#if  __CUDA_ARCH__ < 600 and defined(__CUDA_ARCH__)
+#if  __CUDA_ARCH__ < 600 && defined(__CUDA_ARCH__)
 static __inline__ __device__ double atomicAdd(double* address, double val) {
     unsigned long long int* address_as_ull = (unsigned long long int*)address;
     unsigned long long int old = *address_as_ull, assumed;

--- a/examples/renderers/SoftRas/soft_renderer/cuda/soft_rasterize_cuda_kernel.cu
+++ b/examples/renderers/SoftRas/soft_renderer/cuda/soft_rasterize_cuda_kernel.cu
@@ -26,7 +26,7 @@
 #include <cuda_runtime.h>
 
 // for the older gpus atomicAdd with double arguments does not exist
-#if  __CUDA_ARCH__ < 600 and defined(__CUDA_ARCH__)
+#if  __CUDA_ARCH__ < 600 && defined(__CUDA_ARCH__)
 static __inline__ __device__ double atomicAdd(double* address, double val) {
     unsigned long long int* address_as_ull = (unsigned long long int*)address;
     unsigned long long int old = *address_as_ull, assumed;

--- a/examples/renderers/SoftRas/soft_renderer/cuda/voxelization_cuda_kernel.cu
+++ b/examples/renderers/SoftRas/soft_renderer/cuda/voxelization_cuda_kernel.cu
@@ -29,7 +29,7 @@
 #include <stdio.h>
 
 // for the older gpus atomicAdd with double arguments does not exist
-#if  __CUDA_ARCH__ < 600 and defined(__CUDA_ARCH__)
+#if  __CUDA_ARCH__ < 600 && defined(__CUDA_ARCH__)
 static __inline__ __device__ double atomicAdd(double* address, double val) {
     unsigned long long int* address_as_ull = (unsigned long long int*)address;
     unsigned long long int old = *address_as_ull, assumed;

--- a/kaolin/cuda/mesh_intersection.cpp
+++ b/kaolin/cuda/mesh_intersection.cpp
@@ -17,7 +17,7 @@
 using namespace std;
 
 // CUDA forward declarations
-int MeshIntersectionKernelLauncher(
+void MeshIntersectionKernelLauncher(
     const float* points,
     const float* verts_1,
     const float* verts_2,

--- a/kaolin/graphics/dib_renderer/cuda/rasterizer_cuda_back.cu
+++ b/kaolin/graphics/dib_renderer/cuda/rasterizer_cuda_back.cu
@@ -28,7 +28,7 @@
 #define eps 1e-15
 
 // for the older gpus atomicAdd with double arguments does not exist
-#if __CUDA_ARCH__ < 600 and defined(__CUDA_ARCH__)
+#if __CUDA_ARCH__ < 600 && defined(__CUDA_ARCH__)
 static __inline__ __device__ double atomicAdd(double *address, double val) {
   unsigned long long int *address_as_ull = (unsigned long long int *)address;
   unsigned long long int old = *address_as_ull, assumed;

--- a/kaolin/graphics/softras/cuda/soft_rasterize_cuda_kernel.cu
+++ b/kaolin/graphics/softras/cuda/soft_rasterize_cuda_kernel.cu
@@ -43,7 +43,7 @@
 #include <cuda_runtime.h>
 
 // for the older gpus atomicAdd with double arguments does not exist
-#if  __CUDA_ARCH__ < 600 and defined(__CUDA_ARCH__)
+#if  __CUDA_ARCH__ < 600 && defined(__CUDA_ARCH__)
 static __inline__ __device__ double atomicAdd(double* address, double val) {
     unsigned long long int* address_as_ull = (unsigned long long int*)address;
     unsigned long long int old = *address_as_ull, assumed;

--- a/kaolin/graphics/softras/cuda/voxelization_cuda_kernel.cu
+++ b/kaolin/graphics/softras/cuda/voxelization_cuda_kernel.cu
@@ -46,7 +46,7 @@
 #include <stdio.h>
 
 // for the older gpus atomicAdd with double arguments does not exist
-#if  __CUDA_ARCH__ < 600 and defined(__CUDA_ARCH__)
+#if  __CUDA_ARCH__ < 600 && defined(__CUDA_ARCH__)
 static __inline__ __device__ double atomicAdd(double* address, double val) {
     unsigned long long int* address_as_ull = (unsigned long long int*)address;
     unsigned long long int old = *address_as_ull, assumed;


### PR DESCRIPTION
This PR fixes two issues with compilation on Windows using MSVC. 
- forward declaration inconsistency with the actual definition of the cuda function `MeshIntersectionKernelLauncher` 
- fix of preprocessor condition syntax that was not working properly on MSVC

With these two fixes, I was able to compile on Windows just fine, the setup was the following:
Python version: 3.6
CUDA version: 10.1
Pytorch version: 1.4.0