### PR TITLE
silence deprecation warnings

### DIFF
--- a/kaolin/cuda/mesh_intersection_cuda.cu
+++ b/kaolin/cuda/mesh_intersection_cuda.cu
@@ -104,8 +104,6 @@ void MeshIntersectionKernel(
 			
 			float3 q1 = make_float3(points[ j *3+0], points[ j *3+1], points[ j *3+2]);
 			float3 q2 = make_float3(points[ j *3+0] + 10., points[ j *3+1], points[ j *3+2]);
-			int intersections=0;
-			int end_ka=end_k-(end_k&3);
 			for (int k=0;k<end_k;k++){
 				{		
 

--- a/kaolin/cuda/triangle_distance_cuda.cu
+++ b/kaolin/cuda/triangle_distance_cuda.cu
@@ -135,7 +135,6 @@ void TriangleDistanceKernel(
 			int best_i=0;
 			int best_t=0;
 			float best=0;
-			int end_ka=end_k-(end_k&3);
 			for (int k=0;k<end_k;k++){
 						
 				float3 v1 = make_float3(buf_1[k*3+0], buf_1[k*3+1], buf_1[k*3+2] );

--- a/kaolin/graphics/dib_renderer/cuda/rasterizer_cuda.cu
+++ b/kaolin/graphics/dib_renderer/cuda/rasterizer_cuda.cu
@@ -220,8 +220,6 @@ dr_cuda_forward_prob_batch(const scalar_t *__restrict__ points2d_bxfx6,
     scalar_t x0 = 1.0 * multiplier / width * (2 * wididx + 1 - width);
     scalar_t y0 = 1.0 * multiplier / height * (height - 2 * heiidx - 1);
 
-    int fidxcover = fidxint;
-
     int kid = 0;
 
     for (int fidxint = 0; fidxint < fnum; fidxint++) {


### PR DESCRIPTION
Deprecation warnings ought to be addressed, however in the interim, silencing them will allow spotting more serious issues at build time before they're committed.