### PR TITLE
Refactor KaolinDataset and transforms

### DIFF
--- a/kaolin/helpers.py
+++ b/kaolin/helpers.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Callable
 import numpy as np
 
+
 def _composedecorator(*decs):
     """Returns a composition of several decorators.
 
@@ -99,6 +100,7 @@ def _assert_dim_lt(inp, tgt):
         raise ValueError('Expected input to contain less than {0} dims. '
                          'Got {1} instead.'.format(tgt, inp.dim()))
 
+
 def _assert_dim_ge(inp, tgt):
     """Asserts that the number of dims in inp is greater than or equal to the
     value sepecified in tgt. 
@@ -150,12 +152,12 @@ def _assert_shape_eq(inp, tgt_shape, dim=None):
         if inp.shape != tgt_shape:
             raise ValueError('Size mismatch. Input and target have different '
                              'shapes: {0} vs {1}.'.format(inp.shape,
-                                tgt_shape))
+                                                          tgt_shape))
     else:
         if inp.shape[dim] != tgt_shape[dim]:
             raise ValueError('Size mismatch. Input and target have different '
                              'shapes at dimension {2}: {0} vs {1}.'.format(
-                                inp.shape[dim], tgt_shape[dim], dim))
+                                 inp.shape[dim], tgt_shape[dim], dim))
 
 
 def _assert_gt(inp, val):
@@ -172,7 +174,7 @@ def _get_hash(x):
     if isinstance(x, dict):
         x = tuple(sorted(pair for pair in x.items()))
 
-    return hashlib.md5(bytes(str(x), 'utf-8')).hexdigest()
+    return hashlib.md5(bytes(repr(x), 'utf-8')).hexdigest()
 
 
 class Cache(object):

--- a/kaolin/helpers.py
+++ b/kaolin/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kaolin/transforms/transforms.py
+++ b/kaolin/transforms/transforms.py
@@ -36,6 +36,17 @@ from kaolin.transforms import meshfunc
 from kaolin.transforms import voxelfunc
 
 
+def _get_repr(obj):
+    # TODO: Improve hashing of tensors such that shape matters
+    if isinstance(obj, np.ndarray):
+        return hashlib.sha1(obj).hexdigest()
+
+    if isinstance(obj, torch.Tensor):
+        return hashlib.sha1(obj.cpu().numpy()).hexdigest()
+
+    return repr(obj)
+
+
 class Transform(object):
     """Base class for all Kaolin transforms.
 
@@ -61,14 +72,14 @@ class Transform(object):
     """
 
     def __repr__(self):
-        ignored = set(getattr(self.__class__, '__ignored_params__', []))
+        ignored = set(getattr(self, '__ignored_params__', []))
         names = [
             k for k in self.__dict__.keys()
             if k not in ignored
         ]
         names.sort()
         params = ', '.join([
-            '{}={}'.format(name, repr(self.__dict__[name]))
+            '{}={}'.format(name, _get_repr(self.__dict__[name]))
             for name in names
         ])
         return '{}({})'.format(self.__class__.__name__, params)
@@ -204,8 +215,6 @@ class ScalePointCloud(Transform):
 
     """
 
-    __ignored_params__ = ['inplace']
-
     def __init__(self, scf: Union[int, float, torch.Tensor],
                  inplace: Optional[bool] = True):
         self.scf = scf
@@ -236,8 +245,6 @@ class RotatePointCloud(Transform):
 
     """
 
-    __ignored_params__ = ['inplace']
-
     def __init__(self, rotmat: torch.Tensor, inplace: Optional[bool] = True):
         self.rotmat = rotmat
         self.inplace = inplace
@@ -264,12 +271,7 @@ class RealignPointCloud(Transform):
 
     TODO: Example.
 
-    TODO: This transform's repr is incorrect:
-    changing tgt will not cause caches to recompute.
-
     """
-
-    __ignored_params__ = ['tgt', 'inplace']
 
     def __init__(self, tgt: Union[torch.Tensor, PointCloud],
                  inplace: Optional[bool] = True):
@@ -299,8 +301,6 @@ class NormalizePointCloud(Transform):
     TODO: Example.
 
     """
-
-    __ignored_params__ = ['inplace']
 
     def __init__(self, inplace: Optional[bool] = True):
         self.inplace = inplace
@@ -332,8 +332,6 @@ class DownsampleVoxelGrid(Transform):
     TODO: Example.
 
     """
-
-    __ignored_params__ = ['inplace']
 
     def __init__(self, scale: List[int], inplace=True):
         self.scale = scale
@@ -391,8 +389,6 @@ class ThresholdVoxelGrid(Transform):
         inplace (bool, optional): Bool to make the operation in-place.
 
     """
-
-    __ignored_params__ = ['inplace']
 
     def __init__(self, thresh: float, inplace: Optional[bool] = True):
         self.thresh = thresh
@@ -499,8 +495,6 @@ class SampleTriangleMesh(Transform):
                      for small surface areas.
     """
 
-    __ignored_params__ = ['eps']
-
     def __init__(self, num_samples: int, eps: Optional[float] = 1e-10):
         self.num_samples = num_samples
         self.eps = eps
@@ -531,8 +525,6 @@ class NormalizeMesh(Transform):
     TODO: Example.
 
     """
-
-    __ignored_params__ = ['inplace']
 
     def __init__(self, inplace: Optional[bool] = True):
         self.inplace = inplace
@@ -565,8 +557,6 @@ class ScaleMesh(Transform):
 
     """
 
-    __ignored_params__ = ['inplace']
-
     def __init__(self, scf: Union[float, int, Iterable],
                  inplace: Optional[bool] = True):
         self.scf = scf
@@ -592,8 +582,6 @@ class TranslateMesh(Transform):
         inplace (bool, optional): Bool to make this operation in-place.
     """
 
-    __ignored_params__ = ['inplace']
-
     def __init__(self, trans: Union[torch.Tensor, Iterable],
                  inplace: Optional[bool] = True):
         self.trans = trans
@@ -617,8 +605,6 @@ class RotateMesh(Transform):
         rotmat (torch.Tensor): Rotation matrix (shape: :math:`3 \times 3`).
         inplace (bool, optional): Bool to make this operation in-place.
     """
-
-    __ignored_params__ = ['inplace']
 
     def __init__(self, rotmat: torch.Tensor, inplace: Optional[bool] = True):
         self.rotmat = rotmat
@@ -644,8 +630,6 @@ class TriangleMeshToPointCloud(Transform):
         eps (float, optional): A small number to prevent division by zero
                      for small surface areas.
     """
-
-    __ignored_params__ = ['eps']
 
     def __init__(self, num_samples: int, eps: Optional[float] = 1e-10):
         self.num_samples = num_samples
@@ -771,12 +755,7 @@ class RealignMesh(Transform):
         (torch.Tensor): Pointcloud `src` realigned to fit in the (axis-aligned)
             bounding box of the `tgt` cloud.
 
-    TODO: This transform's repr is incorrect:
-    changing target will not cause caches to recompute.
-
     """
-
-    __ignored_params__ = ['target']
 
     def __init__(self, target: Union[torch.Tensor, PointCloud]):
         self.target = target

--- a/kaolin/transforms/transforms.py
+++ b/kaolin/transforms/transforms.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/datasets/test_ModelNet.py
+++ b/tests/datasets/test_ModelNet.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/datasets/test_ModelNet.py
+++ b/tests/datasets/test_ModelNet.py
@@ -35,6 +35,6 @@ def test_ModelNet(device):
     models = kal.datasets.ModelNet(root=MODELNET_ROOT, categories=['bathtub'], split='test')
 
     assert len(models) == 50
-    for item in models:
-        assert item['attributes']['category'].item() == 0
-        assert isinstance(item['data'], kal.rep.Mesh)
+    for data, attributes in models:
+        assert attributes['category'].item() == 0
+        assert isinstance(data, kal.rep.Mesh)

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -56,12 +56,12 @@ def test_normalize_pointcloud(device='cpu'):
 
 def test_downsample_voxelgrid(device='cpu'):
     voxel = torch.ones([32, 32, 32]).to(device)
-    down = kal.transforms.DownsampleVoxelGrid([2,2,2], inplace=False)
-    helpers._assert_shape_eq(down(voxel), (16,16,16))
-    down = kal.transforms.DownsampleVoxelGrid([3,3,3], inplace=False)
-    helpers._assert_shape_eq(down(voxel), (10,10,10))
-    down = kal.transforms.DownsampleVoxelGrid([3,2,1], inplace=False)
-    helpers._assert_shape_eq(down(voxel), (10,16,32))
+    down = kal.transforms.DownsampleVoxelGrid([2, 2, 2], inplace=False)
+    helpers._assert_shape_eq(down(voxel), (16, 16, 16))
+    down = kal.transforms.DownsampleVoxelGrid([3, 3, 3], inplace=False)
+    helpers._assert_shape_eq(down(voxel), (10, 10, 10))
+    down = kal.transforms.DownsampleVoxelGrid([3, 2, 1], inplace=False)
+    helpers._assert_shape_eq(down(voxel), (10, 16, 32))
 
 
 def test_upsample_voxelgrid(device='cpu'):
@@ -73,11 +73,12 @@ def test_upsample_voxelgrid(device='cpu'):
 
 
 def test_triangle_mesh_to_pointcloud(device='cpu'):
-    mesh = TriangleMesh.from_obj('tests/model.obj') 
+    mesh = TriangleMesh.from_obj('tests/model.obj')
     mesh.to(device)
     mesh2cloud = kal.transforms.TriangleMeshToPointCloud(10000)
     pts = mesh2cloud(mesh)
     helpers._assert_shape_eq(pts, (10000, 3))
+
 
 def test_triangle_mesh_to_voxelgrid(device='cpu'):
     mesh = TriangleMesh.from_obj('tests/model.obj')

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 
 import numpy as np


### PR DESCRIPTION
- Refactored base `KaolinDataset` to return a `namedtuple`, which allows for unpacking, instead of a dictionary.
- Refactored `kaolin.transforms.transforms` to use a common base class that automatically generates `__repr__`.