### PR TITLE
Add a test to check if classification example is running and fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,8 +13,8 @@ test:
     - kaolin
   stage: test
   script:
+    - flake8 --config=.flake8 .
     - source setenv.sh
     - python setup.py develop
+    - pytest --cov=kaolin/ tests/
     - ./tests/examples/run/test_classification.sh
-      #- flake8 --config=.flake8 .
-      #- pytest --cov=kaolin/ tests/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,8 @@ test:
     - kaolin
   stage: test
   script:
-    - flake8 --config=.flake8 .
     - source setenv.sh
     - python setup.py develop
-    - pytest --cov=kaolin/ tests/
+    - ./tests/examples/run/test_classification.sh
+      #- flake8 --config=.flake8 .
+      #- pytest --cov=kaolin/ tests/

--- a/examples/Classification/pointcloud_classification.py
+++ b/examples/Classification/pointcloud_classification.py
@@ -66,7 +66,6 @@ for e in range(args.epochs):
 
     model.train()
 
-    optimizer.zero_grad()
     for idx, batch in enumerate(tqdm(train_loader)):
         category = batch['attributes']['category'].cuda()
         pred = model(batch['data'].cuda())
@@ -74,6 +73,7 @@ for e in range(args.epochs):
         train_loss += loss.item()
         loss.backward()
         optimizer.step()
+        optimizer.zero_grad()
 
         # Compute accuracy
         pred_label = torch.argmax(pred, dim=1)

--- a/examples/Classification/pointcloud_classification.py
+++ b/examples/Classification/pointcloud_classification.py
@@ -1,13 +1,14 @@
 import argparse
+import time
 
 from tqdm import tqdm
 import torch
 from torch.utils.data import DataLoader
+from torch.multiprocessing import cpu_count
 
 from kaolin.datasets import ModelNet
 from kaolin.models.PointNet import PointNetClassifier
 import kaolin.transforms as tfs
-from utils import visualize_batch
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--modelnet-root', type=str, help='Root directory of the ModelNet dataset.')
@@ -16,28 +17,43 @@ parser.add_argument('--num-points', type=int, default=1024, help='Number of poin
 parser.add_argument('--epochs', type=int, default=10, help='Number of train epochs.')
 parser.add_argument('-lr', '--learning-rate', type=float, default=1e-3, help='Learning rate.')
 parser.add_argument('--batch-size', type=int, default=12, help='Batch size.')
-parser.add_argument('--device', type=str, default='cuda', help='Device to use.')
+parser.add_argument('--viz-test', action='store_true', help='Visualize an output of a test sample')
+parser.add_argument('--transforms-device', type=str, default='cuda', help='Device to use.')
 
 args = parser.parse_args()
 
 
+def to_device(inp):
+    inp.to(args.transforms_device)
+    return inp
+
 transform = tfs.Compose([
+    to_device,
     tfs.TriangleMeshToPointCloud(num_samples=args.num_points),
     tfs.NormalizePointCloud()
 ])
 
+if args.transforms_device == 'cuda':
+    num_workers = 0
+    pin_memory = False
+else:
+    num_workers = cpu_count()
+    pin_memory = True
+
 train_loader = DataLoader(ModelNet(args.modelnet_root, categories=args.categories,
-                                   split='train', transform=transform, device=args.device),
-                          batch_size=args.batch_size, shuffle=True)
+                                   split='train', transform=transform),
+                          batch_size=args.batch_size, shuffle=True,
+                          num_workers=num_workers, pin_memory=pin_memory)
 
 val_loader = DataLoader(ModelNet(args.modelnet_root, categories=args.categories,
-                                 split='test', transform=transform, device=args.device),
-                        batch_size=args.batch_size)
+                                 split='test', transform=transform),
+                        batch_size=args.batch_size,
+                        num_workers=num_workers, pin_memory=pin_memory)
 
-model = PointNetClassifier(num_classes=len(args.categories)).to(args.device)
+model = PointNetClassifier(num_classes=len(args.categories)).to('cuda')
 optimizer = torch.optim.Adam(model.parameters(), lr=args.learning_rate)
 criterion = torch.nn.CrossEntropyLoss()
-
+start_time = time.time()
 for e in range(args.epochs):
 
     print('###################')
@@ -52,15 +68,16 @@ for e in range(args.epochs):
 
     optimizer.zero_grad()
     for idx, batch in enumerate(tqdm(train_loader)):
-        pred = model(batch[0])
-        loss = criterion(pred, batch[1].view(-1))
+        category = batch['attributes']['category'].cuda()
+        pred = model(batch['data'].cuda())
+        loss = criterion(pred, category.view(-1))
         train_loss += loss.item()
         loss.backward()
         optimizer.step()
 
         # Compute accuracy
         pred_label = torch.argmax(pred, dim=1)
-        train_accuracy += torch.mean((pred_label == batch[1].view(-1)).float()).detach().cpu().item()
+        train_accuracy += torch.mean((pred_label == category.view(-1)).float()).detach().cpu().item()
         num_batches += 1
 
     print('Train loss:', train_loss / num_batches)
@@ -74,24 +91,28 @@ for e in range(args.epochs):
 
     with torch.no_grad():
         for idx, batch in enumerate(tqdm(val_loader)):
-            pred = model(batch[0])
-            loss = criterion(pred, batch[1].view(-1))
+            category = batch['attributes']['category'].cuda()
+            pred = model(batch['data'].cuda())
+            loss = criterion(pred, category.view(-1))
             val_loss += loss.item()
 
             # Compute accuracy
             pred_label = torch.argmax(pred, dim=1)
-            val_accuracy += torch.mean((pred_label == batch[1].view(-1)).float()).cpu().item()
+            val_accuracy += torch.mean((pred_label == category.view(-1)).float()).cpu().item()
             num_batches += 1
 
     print('Val loss:', val_loss / num_batches)
     print('Val accuracy:', val_accuracy / num_batches)
-
+end_time = time.time()
+print('Training time: {}'.format(end_time - start_time))
 test_loader = DataLoader(ModelNet(args.modelnet_root, categories=args.categories,
-                                  split='test', transform=transform, device=args.device),
-                         shuffle=True, batch_size=15)
+                                  split='test', transform=transform),
+                         shuffle=True, batch_size=15, num_workers=num_workers, pin_memory=pin_memory)
 
-test_batch, labels = next(iter(test_loader))
-preds = model(test_batch)
+test_batch = next(iter(test_loader))
+preds = model(test_batch['data'].cuda())
 pred_labels = torch.max(preds, axis=1)[1]
 
-visualize_batch(test_batch, pred_labels, labels, args.categories)
+if args.viz_test:
+    from utils import visualize_batch
+    visualize_batch(test_batch, pred_labels, labels, args.categories)

--- a/examples/Classification/pointcloud_classification.py
+++ b/examples/Classification/pointcloud_classification.py
@@ -4,7 +4,6 @@ import time
 from tqdm import tqdm
 import torch
 from torch.utils.data import DataLoader
-from torch.multiprocessing import cpu_count
 
 from kaolin.datasets import ModelNet
 from kaolin.models.PointNet import PointNetClassifier
@@ -18,7 +17,8 @@ parser.add_argument('--epochs', type=int, default=10, help='Number of train epoc
 parser.add_argument('-lr', '--learning-rate', type=float, default=1e-3, help='Learning rate.')
 parser.add_argument('--batch-size', type=int, default=12, help='Batch size.')
 parser.add_argument('--viz-test', action='store_true', help='Visualize an output of a test sample')
-parser.add_argument('--transforms-device', type=str, default='cuda', help='Device to use.')
+parser.add_argument('--transforms-device', type=str, default='cuda', help='Device to use for data preprocessing.')
+parser.add_argument('--workers', type=int, default=4, help='number of workers used for each Dataloader')
 
 args = parser.parse_args()
 
@@ -37,7 +37,7 @@ if args.transforms_device == 'cuda':
     num_workers = 0
     pin_memory = False
 else:
-    num_workers = cpu_count()
+    num_workers = args.workers
     pin_memory = True
 
 train_loader = DataLoader(ModelNet(args.modelnet_root, categories=args.categories,

--- a/kaolin/transforms/meshfunc.py
+++ b/kaolin/transforms/meshfunc.py
@@ -65,8 +65,8 @@ def sample_triangle_mesh(vertices: torch.Tensor, faces: torch.Tensor,
     # We want the last dimension of vertices to be of shape 3.
     helpers._assert_shape_eq(vertices, (-1, 3), dim=-1)
 
-    dist_uni = torch.distributions.Uniform(torch.tensor([0.]).to(
-        vertices.device), torch.tensor([1.]).to(vertices.device))
+    dist_uni = torch.distributions.Uniform(torch.zeros((1,), device=vertices.device),
+                                           1.)
 
     # calculate area of each face
     x1, x2, x3 = torch.split(torch.index_select(
@@ -75,9 +75,9 @@ def sample_triangle_mesh(vertices: torch.Tensor, faces: torch.Tensor,
     y1, y2, y3 = torch.split(torch.index_select(
         vertices, 0, faces[:, 1]) - torch.index_select(
         vertices, 0, faces[:, 2]), 1, dim=1)
-    a = (x2 * y3 - x3 * y2)**2
-    b = (x3 * y1 - x1 * y3)**2
-    c = (x1 * y2 - x2 * y1)**2
+    a = (x2 * y3 - x3 * y2) ** 2
+    b = (x3 * y1 - x1 * y3) ** 2
+    c = (x1 * y2 - x2 * y1) ** 2
     Areas = torch.sqrt(a + b + c) / 2
     # percentage of each face w.r.t. full surface area
     Areas = Areas / (torch.sum(Areas) + eps)

--- a/tests/examples/run/test_classification.sh
+++ b/tests/examples/run/test_classification.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+python ${KAOLIN_HOME}/examples/Classification/pointcloud_classification.py \
+    --modelnet-root /data/ModelNet10/ \
+    --categories desk dresser \
+    --epochs 1 --transforms-device cuda
+
+python ${KAOLIN_HOME}/examples/Classification/pointcloud_classification.py \
+    --modelnet-root /data/ModelNet10/ \
+    --categories desk dresser \
+    --epochs 1 --transforms-device cpu


### PR DESCRIPTION
Fix examples/pointcloud_classification.py
new features to the example:
   1) --viz-test argument to avoid plot attempt in CI
   2) Speedup using dataloader multiprocess (speedup variable, x4 on my workstation)
   2) replace --device to be --transforms-device, because depending on your processor applying transforms on GPU may still be more efficient.

Comments:
1) examples/Classification/pointcloud_classification_engine.py is not fixed yet
2) the test will probably need some renaming after #205 

Signed-off-by: cfujitsang <cfujitsang@nvidia.com>