### PR TITLE
windows build fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,6 @@ full test:
     - source setenv.sh
     - python setup.py develop
     - pytest --cov=kaolin/ tests/
-    - ./tests/examples/run/test_classification.sh
-    - ./tests/examples/run/test_nmr.sh
-    - ./tests/examples/run/test_softras_examples.sh
+    - tests/examples/run/test_classification.sh
+    - tests/examples/run/test_nmr.sh
+    - tests/examples/run/test_softras_examples.sh

--- a/kaolin/cuda/cuda_util.h
+++ b/kaolin/cuda/cuda_util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@
 
 // #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#ifndef __NVCC__
 #include <torch/extension.h>
+#endif
 #include <cmath>
 
 #include <cuda.h>

--- a/kaolin/cuda/mesh_intersection.cpp
+++ b/kaolin/cuda/mesh_intersection.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 using namespace std;
 
 // CUDA forward declarations
-int MeshIntersectionKernelLauncher(
+void MeshIntersectionKernelLauncher(
     const float* points,
     const float* verts_1,
     const float* verts_2,

--- a/kaolin/cuda/mesh_intersection_cuda.cu
+++ b/kaolin/cuda/mesh_intersection_cuda.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <torch/extension.h>
 #include <iostream>
 
 using namespace std;

--- a/kaolin/cuda/sided_distance_cuda.cu
+++ b/kaolin/cuda/sided_distance_cuda.cu
@@ -1,4 +1,4 @@
-// Copyright (c) [year] [fullname]
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the "Software"),
@@ -16,8 +16,6 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-#include <torch/extension.h>
 
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/kaolin/graphics/dib_renderer/cuda/rasterizer_cuda_back.cu
+++ b/kaolin/graphics/dib_renderer/cuda/rasterizer_cuda_back.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -28,7 +28,7 @@
 #define eps 1e-15
 
 // for the older gpus atomicAdd with double arguments does not exist
-#if __CUDA_ARCH__ < 600 and defined(__CUDA_ARCH__)
+#if __CUDA_ARCH__ < 600 && defined(__CUDA_ARCH__)
 static __inline__ __device__ double atomicAdd(double *address, double val) {
   unsigned long long int *address_as_ull = (unsigned long long int *)address;
   unsigned long long int old = *address_as_ull, assumed;

--- a/kaolin/graphics/softras/cuda/soft_rasterize_cuda_kernel.cu
+++ b/kaolin/graphics/softras/cuda/soft_rasterize_cuda_kernel.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 // #
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@
 #include <cuda_runtime.h>
 
 // for the older gpus atomicAdd with double arguments does not exist
-#if  __CUDA_ARCH__ < 600 and defined(__CUDA_ARCH__)
+#if  __CUDA_ARCH__ < 600 && defined(__CUDA_ARCH__)
 static __inline__ __device__ double atomicAdd(double* address, double val) {
     unsigned long long int* address_as_ull = (unsigned long long int*)address;
     unsigned long long int old = *address_as_ull, assumed;

--- a/setup.py
+++ b/setup.py
@@ -79,20 +79,24 @@ def read(*names, **kwargs):
 
 
 def KaolinCUDAExtension(*args, **kwargs):
-    FLAGS = ['-Wno-deprecated-declarations']
-    kwargs = copy.deepcopy(kwargs)
-    if 'extra_compile_args' in kwargs:
-        kwargs['extra_compile_args'] += FLAGS
-    else:
-        kwargs['extra_compile_args'] = FLAGS
+    if not os.name == 'nt':
+        FLAGS = ['-Wno-deprecated-declarations']
+        kwargs = copy.deepcopy(kwargs)
+        if 'extra_compile_args' in kwargs:
+            kwargs['extra_compile_args'] += FLAGS
+        else:
+            kwargs['extra_compile_args'] = FLAGS
+
     return CUDAExtension(*args, **kwargs)
 
 
 class KaolinBuildExtension(BuildExtension):
     def build_extensions(self):
-        FLAG_BLACKLIST = ['-Wstrict-prototypes']
-        FLAGS = ['-Wno-deprecated-declarations']
-        self.compiler.compiler_so = [x for x in self.compiler.compiler_so if x not in FLAG_BLACKLIST] + FLAGS  # Covers non-cuda
+        if not os.name == 'nt':
+            FLAG_BLACKLIST = ['-Wstrict-prototypes']
+            FLAGS = ['-Wno-deprecated-declarations']
+            self.compiler.compiler_so = [x for x in self.compiler.compiler_so if x not in FLAG_BLACKLIST] + FLAGS  # Covers non-cuda
+
         super().build_extensions()
 
 


### PR DESCRIPTION
- don't include pytorch in some .cu to avoid constexpr and cast errors from nvcc
- function prototype and preprocessor fixes (some overlap with https://github.com/NVIDIAGameWorks/kaolin/pull/200)
- exclude gcc/clang compiler flags from windows build