### PR TITLE
drop install of gtk from CI steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,9 +6,9 @@ steps:
 - name: test
   image: pytorch/pytorch:1.2-cuda10.0-cudnn7-devel
   commands:
-  - apt-get update && apt-get -y install libgtk2.0-dev
-  - pip install --no-dependencies nuscenes-devkit opencv-python scikit-learn joblib pyquaternion cachetools
+  - pip install --no-dependencies nuscenes-devkit opencv-python-headless scikit-learn joblib pyquaternion cachetools
   - pip install -r requirements.txt
+  - apt-get update && apt-get -y install libglib2.0-0  # needed by opencv
   - flake8 --config=.flake8 .
   - python setup.py develop
   - . ./setenv.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,9 +2,9 @@ image: "pytorch/pytorch:1.2-cuda10.0-cudnn7-devel"
 
 before_script:
   - pip install --upgrade pip>=18.0.0
-  - apt-get update && apt-get -y install libgtk2.0-dev
-  - pip install --no-dependencies nuscenes-devkit opencv-python scikit-learn joblib pyquaternion cachetools
+  - pip install --no-dependencies nuscenes-devkit opencv-python-headless scikit-learn joblib pyquaternion cachetools
   - pip install -r requirements.txt
+  - apt-get update && apt-get -y install libglib2.0-0  # needed by opencv
 
 stages:
   - build

--- a/kaolin/datasets/__init__.py
+++ b/kaolin/datasets/__init__.py
@@ -2,8 +2,15 @@ from .shapenet import *
 from .modelnet import *
 from .shrec import *
 from .scannet import *
+
+# nuscenes-devkit will import matplotlib trying for an x11 backend, workaround here
+import matplotlib
+matplotlib.use('Agg')
+
 try:
     from .nusc import NuscDetection
 except ImportError as err:
     import_err = err
+    import traceback
     print("Warning: unable to import datasets/nusc:\n   %s" % import_err)
+    print("Warning: unable to import datasets/nusc:\n   %s" % traceback.print_exc())

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,11 @@ def KaolinCUDAExtension(*args, **kwargs):
 
 
 class KaolinBuildExtension(BuildExtension):
+    def __init__(self, *args, **kwargs):
+        kwargs = copy.deepcopy(kwargs)
+        kwargs['use_ninja'] = False  # ninja is interfering with compiling separate extensions in parallel
+        super().__init__(*args, **kwargs)
+
     def build_extensions(self):
         if not os.name == 'nt':
             FLAG_BLACKLIST = ['-Wstrict-prototypes']


### PR DESCRIPTION
drop libgtk2.0-dev .deb requirement by:

- switching from opencv-python to opencv-python-headless
- switching matplotlib default backend away from one requiring interactive x11 session