### PR TITLE
add nuscenes-devkit to installation requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -209,6 +209,7 @@ cwd = os.path.dirname(os.path.abspath(__file__))
 def get_requirements():
     return [
         'matplotlib<3.0.0',
+        'nuscenes-devkit',
         'scikit-image',
         'shapely',
         'trimesh>=3.0',


### PR DESCRIPTION
Signed-off-by: Yixing Jiang <ethanjyx@umich.edu>

This library should be required, otherwise I'm getting this error
```
>>> import kaolin as kal
Warning: unable to import datasets/nusc:
   No module named 'nuscenes'
Traceback (most recent call last):
  File "/nfs1/jyx/kaolin/kaolin/datasets/__init__.py", line 11, in <module>
    from .nusc import NuscDetection
  File "/nfs1/jyx/kaolin/kaolin/datasets/nusc.py", line 21, in <module>
    from nuscenes.utils.geometry_utils import transform_matrix
ModuleNotFoundError: No module named 'nuscenes'
Warning: unable to import datasets/nusc:
   None
```