### PR TITLE
enforce versions on dependencies, remove optional dependencies

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
                 flake8-mypy==17.8.0 \
                 flake8-pyi==19.3.0 \
                 pytest==5.4.2 \
-                pycov==2.8.1
+                pytest-cov==2.8.1
   - pip install --no-dependencies -r requirements.txt
   - apt-get update && apt-get -y install libglib2.0-0  # needed by opencv
   - flake8 --config=.flake8 .

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,6 +6,7 @@ steps:
 - name: test
   image: pytorch/pytorch:1.2-cuda10.0-cudnn7-devel
   commands:
+  - pip install --upgrade pip>=18.0.0
   - pip install flake8==3.7.9 \
                 flake8-bugbear==20.1.4 \
                 flake8-comprehensions==3.2.2 \

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,8 +6,14 @@ steps:
 - name: test
   image: pytorch/pytorch:1.2-cuda10.0-cudnn7-devel
   commands:
-  - pip install --no-dependencies nuscenes-devkit opencv-python-headless scikit-learn joblib pyquaternion cachetools
-  - pip install -r requirements.txt
+  - pip install flake8==3.7.9 \
+                flake8-bugbear==20.1.4 \
+                flake8-comprehensions==3.2.2 \
+                flake8-mypy==17.8.0 \
+                flake8-pyi==19.3.0 \
+                pytest==5.4.2 \
+                pycov==2.8.1
+  - pip install --no-dependencies -r requirements.txt
   - apt-get update && apt-get -y install libglib2.0-0  # needed by opencv
   - flake8 --config=.flake8 .
   - python setup.py develop

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,8 +2,14 @@ image: "pytorch/pytorch:1.2-cuda10.0-cudnn7-devel"
 
 before_script:
   - pip install --upgrade pip>=18.0.0
-  - pip install --no-dependencies nuscenes-devkit opencv-python-headless scikit-learn joblib pyquaternion cachetools
-  - pip install -r requirements.txt
+  - pip install flake8==3.7.9 \
+                flake8-bugbear==20.1.4 \
+                flake8-comprehensions==3.2.2 \
+                flake8-mypy==17.8.0 \
+                flake8-pyi==19.3.0 \
+                pytest==5.4.2 \
+                pytest-cov==2.8.1
+  - pip install --no-dependencies -r requirements.txt
   - apt-get update && apt-get -y install libglib2.0-0  # needed by opencv
 
 stages:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Kaolin curates a large _model zoo_ containing reference implementations of popul
 Windows support is in the works and is currently considered experimental.
 
 ### Dependencies
-- numpy >= 1.17
+- numpy >= 1.17, <1.18.4
 - PyTorch >=1.2, <1.5 and Torchvision >=0.4.0, <0.6.0 (see [pytorch.org](http://pytorch.org) for installation instructions)
 
 ### Installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-flake8-bugbear
-flake8-comprehensions
-flake8-mypy
-flake8-pyi
+nuscenes-devkit==1.0.8
+opencv-python-headless==4.2.0.34
+scikit-learn==0.22.2
+joblib==0.14.1
+pyquaternion==0.9.5
+numpy<1.18.4
+cachetools==4.1.0
+sphinx==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -209,18 +209,11 @@ cwd = os.path.dirname(os.path.abspath(__file__))
 def get_requirements():
     return [
         'matplotlib<3.0.0',
-        'scikit-image',
-        'shapely',
+        'scikit-image==0.16.2',
         'trimesh>=3.0',
         'scipy==1.4.1',
-        'sphinx==2.2.0',    # pinned to resolve issue with docutils 0.16b0.dev
-        'pytest>=4.6',
-        'pytest-cov>=2.7',
-        'tqdm',
-        'pytest',
-        'pptk',
-        'autopep8',
-        'flake8',
+        'tqdm==4.32.1',
+        'pptk==0.1.0',
         'pillow<7.0.0',
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ if torch_ver < parse_version('1.2.0') or torch_ver >= parse_version('1.5.0'):
 # Check that torchvision version installed meets minimum requirements
 torchvision_ver = parse_version(torchvision.__version__)
 if torchvision_ver < parse_version('0.4.0') or torchvision_ver >= parse_version('0.6.0'):
-    logger.warning(f'Kaolin is tested with torchvision >=0.4.0, <0.6.0 Found version (torchvision.__version__) instead.')
+    logger.warning(f'Kaolin is tested with torchvision >=0.4.0, <0.6.0 Found version {torchvision.__version__} instead.')
 
 # Get version number from version.py
 version = {}


### PR DESCRIPTION
Fix versioning of dependencies
move optional dependencies to be in requirements or the CI scripts (sphinx, flake8, pytests, ...)

Signed-off-by: cfujitsang <cfujitsang@nvidia.com>