### PR TITLE
Update the pytest part

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Perform from within a `Anaconda Prompt (Anaconda3)`:
 
 From within the previously created kaolin conda environment:
 * `python -c "import kaolin; print(kaolin.__version__)"`
+* `conda install -c anaconda pytest`
 * `pytest tests/`
 
 
@@ -159,6 +160,7 @@ To run unittests, from the root directory of the repository (i.e., the directory
 
 ```bash
 $ . setenv.sh
+$ conda install -c anaconda pytest
 $ pytest tests/
 ```
 


### PR DESCRIPTION
If the **pytest** in the `env: kaolin` isn't installed,  the pytest command will use the pytest in `env: base` instead. 
In such a case, the pytest in `env: base` will reset the env path to `env: base`, making the test failed.