### PR TITLE
Fix trianglemesh_to_voxelgrid

### DIFF
--- a/kaolin/conversions/meshconversions.py
+++ b/kaolin/conversions/meshconversions.py
@@ -133,7 +133,7 @@ def trianglemesh_to_voxelgrid(mesh: kaolin.rep.Mesh, resolution: int,
     del(v1, v2, v3)
 
     voxel = torch.zeros((resolution, resolution, resolution))
-    points = (points * (resolution - 1)).long()
+    points = (points * (resolution - 1) + resolution / 2).long()
     points = torch.split(points.permute(1, 0), 1, dim=0)
     points = [m.unsqueeze(0) for m in points]
     voxel[points] = 1


### PR DESCRIPTION
Thanks for the great work. 

I installed Kaolin using the python setup.py install command, in a conda env with:
Ubuntu 16.04  
pytorch 1.5.1    
torchvision 0.6.1   

And the following bug occurred in my environment.
Hello3Dworld tutorial - strange voxelgrid, pptk viewer permission error #185

I don't know the bug that happens to everyone, but I fixed it like this PR. Please check.

without this PR
![Screenshot from 2020-07-08 17-08-56](https://user-images.githubusercontent.com/39142679/86894270-caee4480-c13d-11ea-8bea-8c95f76a7c3b.png)

with this PR
![Screenshot from 2020-07-08 17-09-08](https://user-images.githubusercontent.com/39142679/86894298-d3df1600-c13d-11ea-8f7f-df453f2ab321.png)
