### PR TITLE
Fix hello3d docs

### DIFF
--- a/docs/notes/hello3d.rst
+++ b/docs/notes/hello3d.rst
@@ -44,7 +44,7 @@ Voxels are another popular 3D representation. Think of them as the 3D extension 
 
 .. code-block:: python
 
-    >>> voxels = kal.conversions.trianglemesh_to_voxelgrid(mesh, 32)
+    >>> voxels = kal.conversions.trianglemesh_to_voxelgrid(mesh, 32, vertex_offset=0.5)
 
 To visualize the voxel grid, run
 


### PR DESCRIPTION
Thanks for the great work. 

I installed Kaolin using the python setup.py install command, in a conda env with:
Ubuntu 16.04  
pytorch 1.5.1    
torchvision 0.6.1   

And the following bug occurred in my environment.
Hello3Dworld tutorial - strange voxelgrid, pptk viewer permission error #185

I thought this was due to a document error and fixed it.
Please confirm.

https://kaolin.readthedocs.io/en/latest/notes/hello3d.html
![image](https://user-images.githubusercontent.com/39142679/86927913-dc9c1000-c16e-11ea-9c7f-245f1675f300.png)

```
voxels = kal.conversions.trianglemesh_to_voxelgrid(mesh, 32)
```
![Screenshot from 2020-07-08 17-08-56](https://user-images.githubusercontent.com/39142679/86894270-caee4480-c13d-11ea-8bea-8c95f76a7c3b.png)

```
voxels = kal.conversions.trianglemesh_to_voxelgrid(mesh, 32, vertex_offset=0.5)
```
![Screenshot from 2020-07-08 17-09-08](https://user-images.githubusercontent.com/39142679/86894298-d3df1600-c13d-11ea-8f7f-df453f2ab321.png)
