### PR TITLE
Add mug to synset_to_label of shapenet

### DIFF
--- a/kaolin/datasets/shapenet.py
+++ b/kaolin/datasets/shapenet.py
@@ -56,7 +56,8 @@ synset_to_label = {'04379243': 'table', '03211117': 'monitor', '04401088': 'phon
                    '03642806': 'laptop', '03710193': 'mailbox', '03761084': 'microwave',
                    '03928116': 'piano', '03938244': 'pillow', '03948459': 'pistol',
                    '04004475': 'printer', '04099429': 'rocket', '04256520': 'sofa',
-                   '04554684': 'washer', '04090263': 'rifle', '02946921': 'can'}
+                   '04554684': 'washer', '04090263': 'rifle', '02946921': 'can',
+                   '03797390': 'mug'}
 
 # Label to Synset mapping (for ShapeNet core classes)
 label_to_synset = {v: k for k, v in synset_to_label.items()}


### PR DESCRIPTION
Thanks for the great work.

Since mug was not in the list, I added it to synnet_to_label of shapenet.

I confirmed the id from the following. Please check it.
http://shapenet.cs.stanford.edu/shapenet/obj-zip/ShapeNetCore2015v0/taxonomy.json
http://shapenet.cs.stanford.edu/shapenet/obj-zip/ShapeNetCore.v1/taxonomy.json
 http://shapenet.cs.stanford.edu/shapenet/obj-zip/ShapeNetCore.v2/taxonomy.json
```
{
    "synsetId": "03797390",
    "name": "mug",
    "children": [
      "02824058",
      "03063599"
    ],
    "numInstances": 214
  },
  {
    "synsetId": "02824058",
    "name": "beer mug,stein",
    "children": [],
    "numInstances": 5
  },
  {
    "synsetId": "03063599",
    "name": "coffee mug",
    "children": [],
    "numInstances": 75
  },
 ```