### PR TITLE
Add voxel_range option for mesh to voxel conversion

### DIFF
--- a/kaolin/conversions/meshconversions.py
+++ b/kaolin/conversions/meshconversions.py
@@ -53,7 +53,8 @@ def trianglemesh_to_pointcloud(mesh: kaolin.rep.Mesh, num_points: int):
 
 
 def trianglemesh_to_voxelgrid(mesh: kaolin.rep.Mesh, resolution: int,
-                              normalize: bool = True, vertex_offset: float = 0.):
+                              normalize: bool = True, vertex_offset: float = 0.,
+                              voxel_range: float = 1.):
     r""" Converts mesh to a voxel model of a given resolution
 
     Args:
@@ -63,6 +64,7 @@ def trianglemesh_to_voxelgrid(mesh: kaolin.rep.Mesh, resolution: int,
             unit cube centered at the origin.
         vertex_offset (float): Offset applied to all vertices after
                                normalizing.
+        voxel_range (float): Range of voxelization.
 
     Returns:
         voxels (torch.Tensor): voxel array of desired resolution
@@ -80,6 +82,7 @@ def trianglemesh_to_voxelgrid(mesh: kaolin.rep.Mesh, resolution: int,
         mesh.vertices = (mesh.vertices - verts_min) / (verts_max - verts_min) - 0.5
 
     mesh.vertices = mesh.vertices + vertex_offset
+    mesh.vertices /= voxel_range
 
     points = mesh.vertices
     smallest_side = (1. / resolution)**2

--- a/kaolin/datasets/shapenet.py
+++ b/kaolin/datasets/shapenet.py
@@ -367,6 +367,7 @@ class ShapeNet_Voxels(data.Dataset):
         split (float): amount of dataset that is training out of 1
         resolutions (list): list of resolutions to be returned
         no_progress (bool): if True, disables progress bar
+        voxel_range (float): Range of voxelization.
 
     Returns:
         .. code-block::
@@ -387,7 +388,8 @@ class ShapeNet_Voxels(data.Dataset):
     """
 
     def __init__(self, root: str, cache_dir: str, categories: list = ['chair'], train: bool = True,
-                 split: float = .7, resolutions=[128, 32], no_progress: bool = False):
+                 split: float = .7, resolutions=[128, 32], no_progress: bool = False,
+                 voxel_range: float = 1.0):
         self.root = Path(root)
         self.cache_dir = Path(cache_dir) / 'voxels'
         self.cache_transforms = {}
@@ -406,7 +408,10 @@ class ShapeNet_Voxels(data.Dataset):
 
         for res in self.params['resolutions']:
             self.cache_transforms[res] = tfs.CacheCompose([
-                tfs.TriangleMeshToVoxelGrid(res, normalize=False, vertex_offset=0.5),
+                tfs.TriangleMeshToVoxelGrid(res,
+                                            normalize=False,
+                                            vertex_offset=0.5,
+                                            voxel_range=voxel_range),
                 tfs.FillVoxelGrid(thresh=0.5),
                 tfs.ExtractProjectOdmsFromVoxelGrid()
             ], self.cache_dir)

--- a/kaolin/transforms/transforms.py
+++ b/kaolin/transforms/transforms.py
@@ -662,15 +662,18 @@ class TriangleMeshToVoxelGrid(Transform):
             unit cube centered at the origin.
         vertex_offset (float): Offset applied to all vertices after
                                normalizing.
+        voxel_range (float): Range of voxelization.
 
     """
 
     def __init__(self, resolution: int,
                  normalize: bool = True,
-                 vertex_offset: float = 0.):
+                 vertex_offset: float = 0.,
+                 voxel_range: float = 1.):
         self.resolution = resolution
         self.normalize = normalize
         self.vertex_offset = vertex_offset
+        self.voxel_range = voxel_range
 
     def __call__(self, mesh: TriangleMesh):
         """
@@ -684,7 +687,8 @@ class TriangleMeshToVoxelGrid(Transform):
         """
         voxels = cvt.trianglemesh_to_voxelgrid(mesh, self.resolution,
                                                normalize=self.normalize,
-                                               vertex_offset=self.vertex_offset)
+                                               vertex_offset=self.vertex_offset,
+                                               voxel_range=self.voxel_range)
         return voxels
 
 


### PR DESCRIPTION
Hi, thank you for the work.

Some meshes cannot be voxelized unless normalize=True.
The ShapeNet_Voxels class also raises an error with some data.
https://github.com/NVIDIAGameWorks/kaolin/blob/ec193fff54bd073cf8cdafaa0fc5f03f7d23e28c/kaolin/datasets/shapenet.py#L409


For example, this object cannot be voxelized.
http://shapenet.cs.stanford.edu/shapenet/obj-zip/ShapeNetCore.v1/04379243/10657fcfce1d326b30bbd4cddd04c77b/model.obj

```
import kaolin as kal

mesh = kal.rep.TriangleMesh.from_obj(
    '/media/kosuke/SANDISK/meshdata/ShapeNetCore.v2/04379243/10657fcfce1d326b30bbd4cddd04c77b/model.obj')
print(mesh.vertices.min(), mesh.vertices.max())  # tensor(-0.3166) tensor(0.5718)
```

The maximum value of this mesh is 0.5718, and when it is moved by the offset, it becomes 1.0718.
Since the range of voxelization is 0 to 1, an error occurs due to overflow.
```
In [2]: voxels = kal.conversions.trianglemesh_to_voxelgrid(mesh, 32, normalize=False, vertex_offset=0.5)
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-2-dd3bce34a4e9> in <module>
----> 1 voxels = kal.conversions.trianglemesh_to_voxelgrid(mesh, 32, normalize=False, vertex_offset=0.5)

~/.pyenv/versions/anaconda3-5.3.1/envs/kaolin/lib/python3.6/site-packages/kaolin-0.1.0-py3.6-linux-x86_64.egg/kaolin/conversions/meshconversions.py in trianglemesh_to_voxelgrid(mesh, resolution, normalize, vertex_offset, voxel_range)
    140     points = torch.split(points.permute(1, 0), 1, dim=0)
    141     points = [m.unsqueeze(0) for m in points]
--> 142     voxel[points] = 1
    143     return voxel
    144

IndexError: index 32 is out of bounds for dimension 0 with size 32
```

This PR solved this problem by expanding voxel_range.
```
In [3]: voxels = kal.conversions.trianglemesh_to_voxelgrid(mesh, 32, normalize=False, vertex_offset=0.5, voxel_range=1.08)
```
