### PR TITLE
Implement IGN_TORCH_VER env var in setup.py

### DIFF
--- a/docs/notes/installation.rst
+++ b/docs/notes/installation.rst
@@ -17,7 +17,7 @@ Requirements
 Dependencies
 ------------
 
-* torch >= 1.5
+* torch >= 1.5, <= 1.7.1
 * cython == 0.29.20
 * scipy >= 1.2.0
 * Pillow >= 8.0.0
@@ -34,7 +34,8 @@ Installation from source
         $ conda create --name kaolin python=3.7
         $ conda activate kaolin
 
-We recommend following instructions from `https://pytorch.org <https://pytorch.org>`_ for installing PyTorch, and `https://cython.readthedocs.io <https://cython.readthedocs.io/en/latest/src/quickstart/install.html>`_ for installing cython, however Kaolin installation will attempt to automatically install the latest if none is installed (may fail on some systems).
+We recommend following instructions from `https://pytorch.org <https://pytorch.org>`_ for installing PyTorch, and `https://cython.readthedocs.io <https://cython.readthedocs.io/en/latest/src/quickstart/install.html>`_ for installing cython, however Kaolin installation will attempt to automatically install the latest compatible version if none is installed (may fail on some systems).
+Kaolin may also function with some incompatible PyTorch versions; to override the PyTorch version check, set environment variable ``export IGNORE_TORCH_VER=1`` before installing.
 
 To install the library. You must first clone the repository:
 

--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,16 @@ else:
     import torch
     torch_ver = parse_version(torch.__version__)
     if (torch_ver < parse_version(TORCH_MIN_VER) or
-       torch_ver > parse_version(TORCH_MAX_VER)) and \
-       not IGNORE_TORCH_VER:
-        warnings.warn(f'Kaolin is compatible with PyTorch >={TORCH_MIN_VER}, <={TORCH_MAX_VER}, '
-                      f'but found version {torch.__version__} instead. '
-                      'This will try to install torch in the right version. '
-                      'If the installation fails we recommend to first install it.')
+       torch_ver > parse_version(TORCH_MAX_VER)):
+        if IGNORE_TORCH_VER:
+            warnings.warn(f'Kaolin is compatible with PyTorch >={TORCH_MIN_VER}, <={TORCH_MAX_VER}, '
+                          f'but found version {torch.__version__}. Continuing with the installed '
+                          'version as IGNORE_TORCH_VER is set.')
+        else:
+            warnings.warn(f'Kaolin is compatible with PyTorch >={TORCH_MIN_VER}, <={TORCH_MAX_VER}, '
+                          f'but found version {torch.__version__} instead. ' 
+                          'This will try to install a compatible version of PyTorch. '
+                          'If the installation fails we recommend to first install it.')
         missing_modules.append(f'torch>={TORCH_MIN_VER},<={TORCH_MAX_VER}')
 
 cython_spec = importlib.util.find_spec("cython")
@@ -117,9 +121,7 @@ write_version_file()
 def get_requirements():
     requirements = []
     if os.name != 'nt':  # no pypi torch for windows
-        if os.getenv('PYTORCH_VERSION'):
-            requirements.append('torch==%s' % os.getenv('PYTORCH_VERSION'))
-        elif IGNORE_TORCH_VER:
+        if IGNORE_TORCH_VER:
             requirements.append('torch')
         else:
             requirements.append(f'torch>={TORCH_MIN_VER},<={TORCH_MAX_VER}')

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@
 # TORCH_CUDA_ARCH_LIST
 #   specify which CUDA architectures to build for
 #
-# IGN_TORCH_VER
-#   ignore version of PyTorch
+# IGNORE_TORCH_VER
+#   ignore version requirements for PyTorch
 
 from os import environ
 from setuptools import setup, find_packages, dist
@@ -16,20 +16,23 @@ TORCH_MIN_VER = '1.5.0'
 TORCH_MAX_VER = '1.7.1'
 CYTHON_MIN_VER = '0.29.20'
 INCLUDE_EXPERIMENTAL = environ.get('KAOLIN_INSTALL_EXPERIMENTAL') is not None
-IGN_TORCH_VER = environ.get('IGN_TORCH_VER') is not None
+IGNORE_TORCH_VER = environ.get('IGNORE_TORCH_VER') is not None
 
 missing_modules = []
 torch_spec = importlib.util.find_spec("torch")
 if torch_spec is None:
     warnings.warn("Couldn't find torch installed, so this will try to install it. "
                   "If the installation fails we recommend to first install it.")
-    missing_modules.append(f'torch>={TORCH_MIN_VER},<={TORCH_MAX_VER}')
+    if IGNORE_TORCH_VER:
+        missing_modules.append('torch')
+    else:
+        missing_modules.append(f'torch>={TORCH_MIN_VER},<={TORCH_MAX_VER}')
 else:
     import torch
     torch_ver = parse_version(torch.__version__)
     if (torch_ver < parse_version(TORCH_MIN_VER) or
        torch_ver > parse_version(TORCH_MAX_VER)) and \
-       not IGN_TORCH_VER:
+       not IGNORE_TORCH_VER:
         warnings.warn(f'Kaolin is compatible with PyTorch >={TORCH_MIN_VER}, <={TORCH_MAX_VER}, '
                       f'but found version {torch.__version__} instead. '
                       'This will try to install torch in the right version. '
@@ -116,7 +119,7 @@ def get_requirements():
     if os.name != 'nt':  # no pypi torch for windows
         if os.getenv('PYTORCH_VERSION'):
             requirements.append('torch==%s' % os.getenv('PYTORCH_VERSION'))
-        elif IGN_TORCH_VER:
+        elif IGNORE_TORCH_VER:
             requirements.append('torch')
         else:
             requirements.append(f'torch>={TORCH_MIN_VER},<={TORCH_MAX_VER}')


### PR DESCRIPTION
Allows for ignoring the installed pytorch version when installing so that recent versions may be used while maintaining explicit version support. Addresses #389.