### PR TITLE
Ignore some errors on ShapeNet

### DIFF
--- a/kaolin/io/obj.py
+++ b/kaolin/io/obj.py
@@ -40,6 +40,9 @@ class MaterialFileError(MaterialError):
 class MaterialNotFoundError(MaterialError):
     pass
 
+def ignore_error_handler(error, **kwargs):
+    """Simple error handler to use in :func:`load_obj` that ignore all errors"""
+    pass
 
 def skip_error_handler(error, **kwargs):
     """Simple error handler to use in :func:`load_obj` that skips all errors

--- a/kaolin/io/obj.py
+++ b/kaolin/io/obj.py
@@ -110,7 +110,6 @@ def import_mesh(path, with_materials=False, with_normals=False,
     materials_order = []
     materials_dict = {}
     materials_idx = {}
-    cur_idx = 0
 
     with open(path, 'r', encoding='utf-8') as f:
         for line in f:
@@ -137,11 +136,10 @@ def import_mesh(path, with_materials=False, with_normals=False,
                     else:
                         face_normals.append([0, 0, 0])
             elif with_materials and data[0] == 'usemtl':
-                cur_idx += len(face_uvs_idx)
                 material_name = data[1]
                 if material_name not in materials_idx:
                     materials_idx[material_name] = len(materials_idx)
-                materials_order.append([materials_idx[material_name], cur_idx])
+                materials_order.append([materials_idx[material_name], len(face_uvs_idx)])
             elif with_materials and data[0] == 'mtllib':
                 mtl_path = os.path.join(os.path.dirname(path), data[1])
                 materials_dict.update(load_mtl(mtl_path, error_handler))

--- a/kaolin/io/shapenet.py
+++ b/kaolin/io/shapenet.py
@@ -16,7 +16,7 @@ import warnings
 from pathlib import Path
 
 from kaolin.io.dataset import KaolinDataset
-from kaolin.io.obj import import_mesh
+from kaolin.io.obj import import_mesh, ignore_error_handler
 
 # Synset to Label mapping (for ShapeNet core classes)
 synset_to_label = {
@@ -127,7 +127,8 @@ class ShapeNet(KaolinDataset):
 
     def get_data(self, index):
         obj_location = self.paths[index] / 'model.obj'
-        mesh = import_mesh(str(obj_location), with_materials=self.with_materials)
+        mesh = import_mesh(str(obj_location), with_materials=self.with_materials,
+                           error_handler=ignore_error_handler)
         return mesh
 
     def get_attributes(self, index):

--- a/tests/python/kaolin/io/test_obj.py
+++ b/tests/python/kaolin/io/test_obj.py
@@ -106,6 +106,10 @@ class TestLoadObj:
                                          [[51,  51,  51],  [51,  51,  51]]]),
              'map_Ks': torch.ByteTensor([[[0,   0,   25],  [0,   0,   25]],
                                          [[51,  51,  25],  [51,  51,  25]]])
+            },
+            {'Ka': torch.tensor([0., 0., 0.]),
+             'Kd': torch.tensor([0., 0., 0.]),
+             'Ks': torch.tensor([0., 0., 0.])
             }
         ]
 
@@ -129,7 +133,7 @@ class TestLoadObj:
                     assert torch.allclose(outputs_material[property_name],
                                           expected_property_val)
             assert torch.equal(outputs.materials_order,
-                               torch.LongTensor([[0, 0], [1, 1]]))
+                               torch.LongTensor([[0, 0], [1, 1], [2, 2]]))
         else:
             assert outputs.materials is None
             assert outputs.materials_order is None

--- a/tests/samples/simple_obj/model.mtl
+++ b/tests/samples/simple_obj/model.mtl
@@ -13,3 +13,8 @@ Ks 0.100000 0.100000 0.100000
 map_Ka ambient_tex_002.png
 map_Kd diffuse_tex_002.png
 map_Ks spec_col_tex_002.png
+
+newmtl Material.003
+Ka 0.000000 0.000000 0.000000
+Kd 0.000000 0.000000 0.000000
+Ks 0.000000 0.000000 0.000000

--- a/tests/samples/simple_obj/model.obj
+++ b/tests/samples/simple_obj/model.obj
@@ -20,3 +20,4 @@ usemtl Material.001
 f 1/1/3 2/2/4 4/4/1 3/3/1
 usemtl Material.002
 f 2/4/4 1/2/3 5/1/2 6/3/2
+usemtl Material.003


### PR DESCRIPTION
ShapeNet has some errors while loading materials because of bad path / missing texture file etc... using `skip_error_handler` would spam too many warnings, so implemented a new error handler that just ignores those errors.

Fix an issue on material_order output by `obj.import_mesh`