### PR TITLE
remove type hints for Cache

### DIFF
--- a/kaolin/io/dataset.py
+++ b/kaolin/io/dataset.py
@@ -44,7 +44,7 @@ class Cache(object):
         cache_key (str): The corresponding cache key for this function.
     """
 
-    def __init__(self, func: Callable, cache_dir: [str, Path], cache_key: str):
+    def __init__(self, func, cache_dir, cache_key):
         self.func = func
         self.cache_dir = Path(cache_dir) / str(cache_key)
         self.cache_dir.mkdir(parents=True, exist_ok=True)

--- a/kaolin/io/dataset.py
+++ b/kaolin/io/dataset.py
@@ -16,7 +16,6 @@ import hashlib
 from abc import abstractmethod
 from collections import namedtuple
 from pathlib import Path
-from typing import Callable
 
 import torch
 from torch.multiprocessing import Pool


### PR DESCRIPTION
This leads to some recent errors on sphinx docstring parsing.

Signed-off-by: Clement Fuji Tsang <cfujitsang@nvidia.com>