### PR TITLE
Fix sparse adjacency matrix by removing duplicates

### DIFF
--- a/kaolin/ops/mesh/mesh.py
+++ b/kaolin/ops/mesh/mesh.py
@@ -66,6 +66,7 @@ def adjacency_matrix(num_vertices, faces, sparse=True):
     forward_i = torch.stack([faces, torch.roll(faces, 1, dims=-1)], dim=-1)
     backward_i = torch.stack([torch.roll(faces, 1, dims=-1), faces], dim=-1)
     indices = torch.cat([forward_i, backward_i], dim=1).reshape(-1, 2)
+    indices = indices.unique(dim=0)
 
     if sparse:
         indices = indices.t()

--- a/kaolin/ops/mesh/mesh.py
+++ b/kaolin/ops/mesh/mesh.py
@@ -56,8 +56,8 @@ def adjacency_matrix(num_vertices, faces, sparse=True):
     Example:
         >>> faces = torch.tensor([[0, 1, 2]])
         >>> adjacency_matrix(3, faces)
-        tensor(indices=tensor([[0, 1, 2, 2, 0, 1],
-                               [2, 0, 1, 0, 1, 2]]),
+        tensor(indices=tensor([[0, 0, 1, 1, 2, 2],
+                               [1, 2, 0, 2, 0, 1]]),
                values=tensor([1., 1., 1., 1., 1., 1.]),
                size=(3, 3), nnz=6, layout=torch.sparse_coo)
     """

--- a/tests/python/kaolin/ops/test_mesh.py
+++ b/tests/python/kaolin/ops/test_mesh.py
@@ -14,6 +14,7 @@
 
 import math
 import pytest
+import os
 
 import torch
 
@@ -22,6 +23,9 @@ from kaolin.ops.batch import get_first_idx, tile_to_packed, list_to_packed
 from kaolin.utils.testing import FLOAT_TYPES, with_seed, check_tensor
 from kaolin.ops import mesh
 from kaolin.ops.mesh.trianglemesh import _unbatched_subdivide_vertices
+from kaolin.io import obj
+
+ROOT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../../samples/')
 
 @pytest.mark.parametrize("device,dtype", FLOAT_TYPES)
 class TestFaceAreas:
@@ -341,7 +345,7 @@ def test_adjacency_matrix_dense(device, dtype):
 
 @pytest.mark.parametrize('device, dtype', FLOAT_TYPES)
 def test_adjacency_consistent(device, dtype):
-    test_mesh = obj.import_mesh('tests/samples/model.obj')
+    test_mesh = obj.import_mesh(os.path.join(ROOT_DIR, 'model.obj'))
     vertices = test_mesh.vertices
     faces = test_mesh.faces
 

--- a/tests/python/kaolin/ops/test_mesh.py
+++ b/tests/python/kaolin/ops/test_mesh.py
@@ -340,6 +340,20 @@ def test_adjacency_matrix_dense(device, dtype):
     assert torch.equal(output, expected)
 
 @pytest.mark.parametrize('device, dtype', FLOAT_TYPES)
+def test_adjacency_consistent(device, dtype):
+    test_mesh = obj.import_mesh('tests/samples/model.obj')
+    vertices = test_mesh.vertices
+    faces = test_mesh.faces
+
+    num_vertices = vertices.shape[0]
+
+    sparse = mesh.adjacency_matrix(num_vertices, faces)
+    sparse_to_dense = sparse.to_dense()
+    dense = mesh.adjacency_matrix(num_vertices, faces, sparse=False)
+
+    assert torch.equal(sparse_to_dense, dense)
+
+@pytest.mark.parametrize('device, dtype', FLOAT_TYPES)
 class TestUniformLaplacian:
 
     def test_uniform_laplacian(self, device, dtype):


### PR DESCRIPTION
Simple fix for issue #401 

While it works, I should note that there seems to be a problem with the efficiency of the `unique` method. See the following issue in PyTorch repo: https://github.com/pytorch/pytorch/issues/15804

I hope it's ok to reference another projects: PyTorch3D faced this problem and solved it with a hash.

https://github.com/facebookresearch/pytorch3d/blob/f00ef66727194df34492ecbc75d81006c96fb424/pytorch3d/structures/meshes.py#L1076-L1083 