### PR TITLE
fix tests for Ampere

### DIFF
--- a/tests/python/kaolin/ops/spc/test_conv.py
+++ b/tests/python/kaolin/ops/spc/test_conv.py
@@ -27,6 +27,8 @@ from kaolin.ops import spc
 
 from kaolin.utils.testing import FLOAT_TYPES, with_seed, check_tensor
 
+os.environ['NVIDIA_TF32_OVERRIDE'] = '0'
+
 @pytest.mark.parametrize('batch_size', [1, 3])
 @pytest.mark.parametrize('height,width,depth,threshold',
                          [(27, 37, 37, 0.7), (64, 64, 64, 0.)])

--- a/tests/python/kaolin/ops/test_gcn.py
+++ b/tests/python/kaolin/ops/test_gcn.py
@@ -14,10 +14,12 @@
 
 import pytest
 import torch
+import os
 
 from kaolin.ops.gcn import sparse_bmm, normalize_adj, GraphConv
 from kaolin.utils.testing import ALL_DEVICES
 
+os.environ['NVIDIA_TF32_OVERRIDE'] = '0'
 
 @pytest.mark.parametrize('device', ALL_DEVICES)
 def test_sparse_bmm(device):


### PR DESCRIPTION
disable usage of TF32 in tests using conv and matmul for Ampere
Signed-off-by: Clement Fuji Tsang <cfujitsang@nvidia.com>