### PR TITLE
Fix #453, return_sparse for trianglemeshes_to_voxelgrids

### DIFF
--- a/kaolin/ops/conversions/pointcloud.py
+++ b/kaolin/ops/conversions/pointcloud.py
@@ -60,7 +60,11 @@ def _base_points_to_voxelgrids(points, resolution, return_sparse=False):
     pc_index = pc_index[row_cond, :]
     pc_index = pc_index.reshape(-1, 4)
 
-    vg = torch.sparse.FloatTensor(pc_index.T, torch.ones(pc_index.shape[0], device=pc_index.device), vg_size)
+    vg = torch.sparse.FloatTensor(
+        pc_index.T,
+        torch.ones(pc_index.shape[0], device=pc_index.device, dtype=dtype),
+        vg_size
+    )
 
     if not return_sparse:
         vg = vg.to_dense().to(dtype)

--- a/tests/python/kaolin/ops/conversions/test_trianglemesh.py
+++ b/tests/python/kaolin/ops/conversions/test_trianglemesh.py
@@ -20,10 +20,8 @@ from kaolin.ops.conversions import trianglemeshes_to_voxelgrids
 from kaolin.utils.testing import FLOAT_TYPES
 
 
-@pytest.mark.parametrize(
-    'device, dtype, return_sparse',
-    [x + (return_sparse, ) for x in FLOAT_TYPES for return_sparse in [True, False]]
-)
+@pytest.mark.parametrize('device, dtype', FLOAT_TYPES)
+@pytest.mark.parametrize('return_sparse', [True, False])
 class TestTriangleMeshToVoxelgrid:
 
     def test_resolution_type(self, device, dtype, return_sparse):

--- a/tests/python/kaolin/ops/conversions/test_trianglemesh.py
+++ b/tests/python/kaolin/ops/conversions/test_trianglemesh.py
@@ -19,10 +19,14 @@ import torch
 from kaolin.ops.conversions import trianglemeshes_to_voxelgrids
 from kaolin.utils.testing import FLOAT_TYPES
 
-@pytest.mark.parametrize('device, dtype', FLOAT_TYPES)
+
+@pytest.mark.parametrize(
+    'device, dtype, return_sparse',
+    [x + (return_sparse, ) for x in FLOAT_TYPES for return_sparse in [True, False]]
+)
 class TestTriangleMeshToVoxelgrid:
 
-    def test_resolution_type(self, device, dtype):
+    def test_resolution_type(self, device, dtype, return_sparse):
         vertices = torch.tensor([[[0, 0, 0],
                                   [1, 0, 0],
                                   [0, 0, 1]]], dtype=dtype, device=device)
@@ -35,9 +39,11 @@ class TestTriangleMeshToVoxelgrid:
 
         with pytest.raises(TypeError, match=r"Expected resolution to be int "
                                             r"but got .*"):
-            trianglemeshes_to_voxelgrids(vertices, faces, 2.3, origins, scale)
+            trianglemeshes_to_voxelgrids(
+                vertices, faces, 2.3, origins, scale, return_sparse
+            )
 
-    def test_mesh_to_voxel_batched(self, device, dtype):
+    def test_mesh_to_voxel_batched(self, device, dtype, return_sparse):
         vertices = torch.tensor([[[0, 0, 0],
                                   [1, 0, 0],
                                   [0, 0, 1]],
@@ -52,7 +58,9 @@ class TestTriangleMeshToVoxelgrid:
 
         scale = torch.ones((2), dtype=dtype, device=device)
 
-        output = trianglemeshes_to_voxelgrids(vertices, faces, 3, origins, scale)
+        output = trianglemeshes_to_voxelgrids(
+            vertices, faces, 3, origins, scale, return_sparse
+        )
 
         # output voxelgrid should have value around the corner
         expected = torch.tensor([[[[1., 1., 1.],
@@ -79,9 +87,11 @@ class TestTriangleMeshToVoxelgrid:
                                    [0., 0., 0.],
                                    [0., 0., 0.]]]],device=device, dtype=dtype)
 
+        if return_sparse:
+            output = output.to_dense()
         assert torch.equal(output, expected)
 
-    def test_mesh_to_voxel_origins(self, device, dtype):
+    def test_mesh_to_voxel_origins(self, device, dtype, return_sparse):
         vertices = torch.tensor([[[0, 0, 0],
                                   [1, 0, 0],
                                   [0, 0, 1]]], dtype=dtype, device=device)
@@ -93,7 +103,9 @@ class TestTriangleMeshToVoxelgrid:
 
         scale = torch.ones((1), dtype=dtype, device=device)
 
-        output = trianglemeshes_to_voxelgrids(vertices, faces, 3, origins, scale)
+        output = trianglemeshes_to_voxelgrids(
+            vertices, faces, 3, origins, scale, return_sparse
+        )
 
         expected = torch.tensor([[[[1., 1., 0.],
                                    [0., 0., 0.],
@@ -106,9 +118,12 @@ class TestTriangleMeshToVoxelgrid:
                                   [[0., 0., 0.],
                                    [0., 0., 0.],
                                    [0., 0., 0.]]]], device=device, dtype=dtype)
+
+        if return_sparse:
+            output = output.to_dense()
         assert torch.equal(output, expected)
 
-    def test_mesh_to_voxel_scale(self, device, dtype):
+    def test_mesh_to_voxel_scale(self, device, dtype, return_sparse):
         vertices = torch.tensor([[[0, 0, 0],
                                   [1, 0, 0],
                                   [0, 0, 1]]], dtype=dtype, device=device)
@@ -119,7 +134,9 @@ class TestTriangleMeshToVoxelgrid:
 
         scale = torch.ones((1), dtype=dtype, device=device) * 2
 
-        output = trianglemeshes_to_voxelgrids(vertices, faces, 3, origins, scale)
+        output = trianglemeshes_to_voxelgrids(
+            vertices, faces, 3, origins, scale, return_sparse
+        )
 
         expected = torch.tensor([[[[1., 1., 0.],
                                    [0., 0., 0.],
@@ -133,9 +150,11 @@ class TestTriangleMeshToVoxelgrid:
                                    [0., 0., 0.],
                                    [0., 0., 0.]]]], device=device, dtype=dtype)
 
+        if return_sparse:
+            output = output.to_dense()
         assert torch.equal(output, expected)
 
-    def test_mesh_to_voxel_resolution_3(self, device, dtype):
+    def test_mesh_to_voxel_resolution_3(self, device, dtype, return_sparse):
         vertices = torch.tensor([[[0, 0, 0],
                                   [1, 0, 0],
                                   [0, 0, 1]]], dtype=dtype, device=device)
@@ -146,7 +165,9 @@ class TestTriangleMeshToVoxelgrid:
 
         scale = torch.ones((1), dtype=dtype, device=device)
 
-        output = trianglemeshes_to_voxelgrids(vertices, faces, 3, origins, scale)
+        output = trianglemeshes_to_voxelgrids(
+            vertices, faces, 3, origins, scale, return_sparse
+        )
 
         expected = torch.tensor([[[[1., 1., 1.],
                                    [0., 0., 0.],
@@ -160,9 +181,11 @@ class TestTriangleMeshToVoxelgrid:
                                    [0., 0., 0.],
                                    [0., 0., 0.]]]], device=device, dtype=dtype)
 
+        if return_sparse:
+            output = output.to_dense()
         assert torch.equal(output, expected)
     
-    def test_rectangle(self, device, dtype):
+    def test_rectangle(self, device, dtype, return_sparse):
         vertices = torch.tensor([[0, 0, 0],
                                  [8, 0, 0],
                                  [0, 8, 0],
@@ -191,7 +214,9 @@ class TestTriangleMeshToVoxelgrid:
 
         scale = torch.ones((1), dtype=dtype, device=device) * 8
 
-        output = trianglemeshes_to_voxelgrids(vertices.unsqueeze(0), faces, 4, origin, scale)
+        output = trianglemeshes_to_voxelgrids(
+            vertices.unsqueeze(0), faces, 4, origin, scale, return_sparse
+        )
 
         expected = torch.tensor([[[[1., 1., 1., 1.],
                                    [1., 1., 1., 1.],
@@ -213,4 +238,6 @@ class TestTriangleMeshToVoxelgrid:
                                    [1., 1., 1., 1.],
                                    [1., 1., 1., 1.]]]], device=device, dtype=dtype)
 
+        if return_sparse:
+            output = output.to_dense()
         assert torch.equal(output, expected)


### PR DESCRIPTION
- Add test for return_sparse=True for trianglemeshes_to_voxelgrids
- Fix return_sparse=True for trianglemeshes_to_voxelgrids

This solution might be a bit less memory efficient, because of the use of `torch.cat`, but as far as I know, one cannot do `voxelgrids[i] = voxelgrid` with sparse tensors.