### PR TITLE
Add depth outputs from SPC raytracing, slight API refactor, fix raytrace AABB behaviour

### DIFF
--- a/docs/modules/kaolin.ops.spc.rst
+++ b/docs/modules/kaolin.ops.spc.rst
@@ -249,11 +249,11 @@ To apply ray tracing we currently only support non-batched version, for instance
 >>> max_level, pyramids, exsum = kaolin.ops.spc.scan_octrees(
 ...     octree, torch.tensor([len(octree)], dtype=torch.int32, device='cuda')
 >>> point_hierarchy = kaolin.ops.spc.generate_points(octrees, pyramids, exsum)
->>> nuggets = kaolin.render.spc.unbatched_raytrace(octree, point_hierarchy, pyramids[0], exsum,
-...                                                origin, direction, max_level)
->>> first_hits_mask = kaolin.render.spc.mark_first_hit(nuggets)
->>> first_hits_nuggets = nuggets[first_hits_mask].long()
->>> first_hits_rgb = rgb[first_hits_nuggets[:, 1] - pyramids[max_level - 2]]
+>>> ridx, pidx, depth = kaolin.render.spc.unbatched_raytrace(octree, point_hierarchy, pyramids[0], exsum,
+...                                                          origin, direction, max_level)
+>>> first_hits_mask = kaolin.render.spc.mark_pack_boundary(ridx)
+>>> first_hits_point = pidx[first_hits_mask]
+>>> first_hits_rgb = rgb[first_hits_point - pyramids[max_level - 2]]
 
 
 API

--- a/kaolin/csrc/bindings.cpp
+++ b/kaolin/csrc/bindings.cpp
@@ -73,11 +73,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   render_mesh.def("generate_soft_mask_cuda", &generate_soft_mask_cuda);
   render_mesh.def("rasterize_backward_cuda", &rasterize_backward_cuda);
   py::module render_spc = render.def_submodule("spc");
-  render_spc.def("ray_aabb", &spc_ray_aabb); // Deprecate soon
   render_spc.def("raytrace_cuda", &raytrace_cuda);
   render_spc.def("generate_primary_rays_cuda", &generate_primary_rays_cuda); // Deprecate soon
-  render_spc.def("remove_duplicate_rays_cuda", &remove_duplicate_rays_cuda);
-  render_spc.def("mark_first_hit_cuda", &mark_first_hit_cuda);
+  render_spc.def("mark_pack_boundary_cuda", &mark_pack_boundary_cuda);
   render_spc.def("generate_shadow_rays_cuda", &generate_shadow_rays_cuda); // Deprecate soon
 }
 

--- a/kaolin/csrc/render/spc/raytrace.h
+++ b/kaolin/csrc/render/spc/raytrace.h
@@ -33,32 +33,20 @@ std::vector<at::Tensor> generate_primary_rays_cuda(
     float fov,
     at::Tensor World);
 
-at::Tensor raytrace_cuda(
+std::vector<at::Tensor> raytrace_cuda(
     at::Tensor octree,
     at::Tensor points,
     at::Tensor pyramid,
     at::Tensor exclusive_sum,
     at::Tensor ray_o,
     at::Tensor ray_d,
-    uint target_level) ;
+    uint target_level,
+    bool return_depth,
+    bool with_exit);
 
 
-at::Tensor remove_duplicate_rays_cuda(
-    at::Tensor nuggets);
-
-at::Tensor mark_first_hit_cuda(
-    at::Tensor nuggets);
-
-std::vector<torch::Tensor> spc_ray_aabb(
-    torch::Tensor nuggets,
-    torch::Tensor points,
-    torch::Tensor ray_query,
-    torch::Tensor ray_d,
-    uint targetLevel,
-    torch::Tensor info,
-    torch::Tensor info_idxes,
-    torch::Tensor cond,
-    bool init);
+at::Tensor mark_pack_boundary_cuda(
+    at::Tensor pack_ids);
 
 std::vector<at::Tensor> generate_shadow_rays_cuda(
     at::Tensor ray_o,


### PR DESCRIPTION
Summary of changes: 

- `mark_first_hits` is now `mark_pack_boundary` which a more general packed operation.
- SPC `raytrace` can now return depth. This deprecates the need for the old `ray_aabb` function. 
- Some edge cases in raytracing is handled differently now. Before, rays could miss if they are exactly between 2 voxels, but now it will hit both. 
- `raytrace` will now return 2 tensors, the ray index and the point hierarchy index. Previously these 2 tensors were stored as a single tensor, which was confusing.
- Other misc enhancements and fixes. 

This also addresses https://github.com/NVIDIAGameWorks/kaolin/issues/463 .