### PR TITLE
Add differentiable volumetric rendering ops for SPC

### DIFF
--- a/kaolin/csrc/bindings.cpp
+++ b/kaolin/csrc/bindings.cpp
@@ -77,6 +77,11 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   render_spc.def("generate_primary_rays_cuda", &generate_primary_rays_cuda); // Deprecate soon
   render_spc.def("mark_pack_boundary_cuda", &mark_pack_boundary_cuda);
   render_spc.def("generate_shadow_rays_cuda", &generate_shadow_rays_cuda); // Deprecate soon
+  render_spc.def("inclusive_sum_cuda", &inclusive_sum_cuda);
+  render_spc.def("diff_cuda", &diff_cuda);
+  render_spc.def("sum_reduce_cuda", &sum_reduce_cuda);
+  render_spc.def("cumsum_cuda", &cumsum_cuda);
+  render_spc.def("cumprod_cuda", &cumprod_cuda);
 }
 
 }  // namespace kaolin

--- a/kaolin/csrc/render/spc/raytrace.h
+++ b/kaolin/csrc/render/spc/raytrace.h
@@ -54,6 +54,29 @@ std::vector<at::Tensor> generate_shadow_rays_cuda(
     at::Tensor light,
     at::Tensor plane);
 
+at::Tensor diff_cuda(
+    at::Tensor feats,
+    at::Tensor pack_indices);
+
+at::Tensor inclusive_sum_cuda(
+    at::Tensor info);
+
+at::Tensor sum_reduce_cuda(
+    at::Tensor feats,
+    at::Tensor inclusive_sum);
+
+at::Tensor cumsum_cuda(
+    at::Tensor feats,
+    at::Tensor pack_indices,
+    bool exclusive,
+    bool reverse);
+
+at::Tensor cumprod_cuda(
+    at::Tensor feats,
+    at::Tensor pack_indices,
+    bool exclusive,
+    bool reverse);
+
 }  // namespace kaolin
 
 #endif  // KAOLIN_OPS_RENDER_SPC_RAYTRACE_H_

--- a/kaolin/render/spc/raytrace.py
+++ b/kaolin/render/spc/raytrace.py
@@ -97,7 +97,7 @@ def mark_pack_boundary(pack_ids):
                                  This can be any integral (n-bit integer) type.
     Returns:
         first_hits (torch.BoolTensor): the boolean mask marking the boundaries.
-    
+
     Examples:
         >>> pack_ids = torch.IntTensor([1,1,1,1,2,2,2])
         >>> mark_pack_boundary(pack_ids)
@@ -153,7 +153,7 @@ class SumReduce(torch.autograd.Function):
         inclusive_sum = _C.render.spc.inclusive_sum_cuda(info.int())
         ctx.save_for_backward(inclusive_sum)
         return _C.render.spc.sum_reduce_cuda(feats, inclusive_sum.contiguous())
-   
+
     @staticmethod 
     def backward(ctx, grad_output):
         inclusive_sum = ctx.saved_tensors[0]
@@ -197,10 +197,10 @@ class Cumsum(torch.autograd.Function):
         ctx.flags = (exclusive, reverse)
         cumsum = _C.render.spc.cumsum_cuda(feats, nonzero, exclusive, reverse)
         return cumsum
-        
+
     @staticmethod
     def backward(ctx, grad_output):
-        nonzero,  = ctx.saved_tensors
+        nonzero, = ctx.saved_tensors
         exclusive, reverse = ctx.flags
         cumsum = _C.render.spc.cumsum_cuda(grad_output.contiguous(), nonzero, exclusive, not reverse)
         return cumsum, None, None, None
@@ -240,7 +240,7 @@ def cumsum(feats, boundaries, exclusive=False, reverse=False):
 
 def cumprod(feats, boundaries, exclusive=False, reverse=False):
     r"""Cumulative product across packs of features.
-    
+
     This function is similar to `tf.math.cumprod` with the same options, but for packed tensors.
     Refer to the TensorFlow docs for numerical examples of the options.
 
@@ -279,7 +279,7 @@ def exponential_integration(feats, tau, boundaries, exclusive=False):
             Given some index array marking the pack IDs, the boundaries can be calculated with
             `mark_pack_boundaries`.
         exclusive (bool): Compute exclusive exponential integration if true.
-    
+
     Returns:
         (torch.FloatTensor, torch.FloatTensor)
         - Integrated features of shape :math:`(\text{num_packs}, \text{num_feats})`.

--- a/kaolin/render/spc/raytrace.py
+++ b/kaolin/render/spc/raytrace.py
@@ -90,7 +90,7 @@ def mark_pack_boundary(pack_ids):
 
     For example, the SPC ray trace kernel will return the ray index tensor which marks the ID of the ray
     that each intersection belongs in. This kernel will mark the beginning of each of those packs of
-    intersections with a boolean mask (`True` where the beginning is).
+    intersections with a boolean mask (true where the beginning is).
 
     Args:
         pack_ids (torch.Tensor): pack ids of shape :math:`(\text{num_elems})`
@@ -109,10 +109,10 @@ def mark_first_hit(ridx):
     r"""Mark the first hit in the nuggets.
 
     .. deprecated:: 0.10.0
-       This function is deprecated. Use `mark_pack_boundary`.
+       This function is deprecated. Use :func:`mark_pack_boundary`.
 
     The nuggets are a packed tensor containing correspondences from ray index to point index, sorted
-    within each ray pack by depth. This will mark True for each first hit (by depth) for a pack of
+    within each ray pack by depth. This will mark true for each first hit (by depth) for a pack of
     nuggets.
 
     Returns:
@@ -124,18 +124,18 @@ def mark_first_hit(ridx):
 def diff(feats, boundaries):
     r"""Find the delta between each of the features in a pack.
 
-    The deltas are given by `out[i] = feats[i+1] - feats[i]`.
+    The deltas are given by `out[i] = feats[i+1] - feats[i]`
 
-    The behavior is similar to torch.diff for non-packed tensors, but :func:`torch.diff` will reduce the
-    number of features by 1. This function will instead populate the last diff with 0.
+    The behavior is similar to :func:`torch.diff` for non-packed tensors, but :func:`torch.diff` 
+    will reduce the number of features by 1. This function will instead populate the last diff with 0.
 
     Args:
-        feats (torch.FloatTensor): features of shape :math:`(\text{num_rays}, \text{num_feats}) `.
-        boundaries (torch.BoolTensor): bools of shape :math:`(\text{num_rays}) `.
+        feats (torch.FloatTensor): features of shape :math:`(\text{num_rays}, \text{num_feats})`
+        boundaries (torch.BoolTensor): bools of shape :math:`(\text{num_rays})`
             Given some index array marking the pack IDs, the boundaries can be calculated with
-            :func:`mark_pack_boundaries`.
+            :func:`mark_pack_boundaries`
     Returns:
-        (torch.FloatTensor): diffed features of shape :math:`(\text{num_rays}, \text{num_feats}) `.
+        (torch.FloatTensor): diffed features of shape :math:`(\text{num_rays}, \text{num_feats})`
     """
 
     feats_shape = feats.shape
@@ -209,39 +209,39 @@ def sum_reduce(feats, boundaries):
     r"""Sum the features of packs.
 
     Args:
-        feats (torch.FloatTensor): features of shape :math:`(\text{num_rays}, \text{num_feats}) `.
-        boundaries (torch.BoolTensor): bools to mark pack boundaries of shape :math:`(\text{num_rays}) `.
+        feats (torch.FloatTensor): features of shape :math:`(\text{num_rays}, \text{num_feats})`.
+        boundaries (torch.BoolTensor): bools to mark pack boundaries of shape :math:`(\text{num_rays})`.
             Given some index array marking the pack IDs, the boundaries can be calculated with
-            `mark_pack_boundaries`.
+            :func:`mark_pack_boundaries`.
     Returns:
-        (torch.FloatTensor): summed features of shape :math:`(\text{num_packs}, \text{num_feats}) `.
+        (torch.FloatTensor): summed features of shape :math:`(\text{num_packs}, \text{num_feats})`.
     """
     return SumReduce.apply(feats.contiguous(), boundaries.contiguous())
 
 def cumsum(feats, boundaries, exclusive=False, reverse=False):
     r"""Cumulative sum across packs of features.
 
-    This function is similar to `tf.math.cumsum` with the same options, but for packed tensors.
+    This function is similar to :func:`tf.math.cumsum` with the same options, but for packed tensors.
     Refer to the TensorFlow docs for numerical examples of the options.
 
     Args:
-        feats (torch.FloatTensor): features of shape :math:`(\text{num_rays}, \text{num_feats}) `.
-        boundaries (torch.BoolTensor): bools of shape :math:`(\text{num_rays}) `.
+        feats (torch.FloatTensor): features of shape :math:`(\text{num_rays}, \text{num_feats})`.
+        boundaries (torch.BoolTensor): bools of shape :math:`(\text{num_rays})`.
             Given some index array marking the pack IDs, the boundaries can be calculated with
-            `mark_pack_boundaries`.
+            :func:`mark_pack_boundaries`.
         exclusive (bool): Compute exclusive cumsum if true. Exclusive means the current index won't be used
                         for the calculation of the cumulative sum. (Default: False)
         reverse (bool): Compute reverse cumsum if true, i.e. the cumulative sum will start from the end of 
                         each pack, not from the beginning. (Default: False)
     Returns:
-        (torch.FloatTensor): features of shape :math:`(\text{num_rays}, \text{num_feats}) `.
+        (torch.FloatTensor): features of shape :math:`(\text{num_rays}\, \text{num_feats})`.
     """
     return Cumsum.apply(feats.contiguous(), boundaries.contiguous(), exclusive, reverse)
 
 def cumprod(feats, boundaries, exclusive=False, reverse=False):
     r"""Cumulative product across packs of features.
 
-    This function is similar to `tf.math.cumprod` with the same options, but for packed tensors.
+    This function is similar to :func:`tf.math.cumprod` with the same options, but for packed tensors.
     Refer to the TensorFlow docs for numerical examples of the options.
 
     Note that the backward gradient follows the same behaviour in TensorFlow, which is to
@@ -249,16 +249,16 @@ def cumprod(feats, boundaries, exclusive=False, reverse=False):
     add an epsilon to feats which will make the behaviour consistent.
 
     Args:
-        feats (torch.FloatTensor): features of shape :math:`(\text{num_rays}, \text{num_feats}) `.
-        boundaries (torch.BoolTensor): bools of shape :math:`(\text{num_rays}) `.
+        feats (torch.FloatTensor): features of shape :math:`(\text{num_rays}, \text{num_feats})`.
+        boundaries (torch.BoolTensor): bools of shape :math:`(\text{num_rays})`.
             Given some index array marking the pack IDs, the boundaries can be calculated with
-            `mark_pack_boundaries`.
+            :func:`mark_pack_boundaries`.
         exclusive (bool): Compute exclusive cumprod if true. Exclusive means the current index won't be used
                         for the calculation of the cumulative product. (Default: False)
         reverse (bool): Compute reverse cumprod if true, i.e. the cumulative product will start from the end of 
                         each pack, not from the beginning. (Default: False)
     Returns:
-        (torch.FloatTensor): features of shape :math:`(\text{num_rays}, \text{num_feats}) `.
+        (torch.FloatTensor): features of shape :math:`(\text{num_rays}, \text{num_feats})`.
     """
     return Cumprod.apply(feats.contiguous(), boundaries.contiguous(), exclusive, reverse)
 
@@ -266,18 +266,18 @@ def exponential_integration(feats, tau, boundaries, exclusive=False):
     r"""Exponential transmittance integration across packs using the optical thickness (tau).
 
     Exponential transmittance is derived from the Beer-Lambert law. Typical implementations of
-    exponential transmittance is calculated with `cumprod`, but the exponential allows a reformulation
-    as a `cumsum` which its gradient is more stable and faster to compute. We opt to use the `cumsum`
+    exponential transmittance is calculated with :func:`cumprod`, but the exponential allows a reformulation
+    as a :func:`cumsum` which its gradient is more stable and faster to compute. We opt to use the :func:`cumsum`
     formulation.
 
     For more details, we recommend "Monte Carlo Methods for Volumetric Light Transport" by Novak et al.
 
     Args:
-        feats (torch.FloatTensor): features of shape :math:`(\text{num_rays}, \text{num_feats}) `.
-        tau (torch.FloatTensor): optical thickness of shape :math:`(\text{num_rays}, 1) `.
-        boundaries (torch.BoolTensor): bools of shape :math:`(\text{num_rays}) `.
+        feats (torch.FloatTensor): features of shape :math:`(\text{num_rays}, \text{num_feats})`.
+        tau (torch.FloatTensor): optical thickness of shape :math:`(\text{num_rays}, 1)`.
+        boundaries (torch.BoolTensor): bools of shape :math:`(\text{num_rays})`.
             Given some index array marking the pack IDs, the boundaries can be calculated with
-            `mark_pack_boundaries`.
+            :func:`mark_pack_boundaries`.
         exclusive (bool): Compute exclusive exponential integration if true.
 
     Returns:

--- a/tests/python/kaolin/render/spc/test_rayops.py
+++ b/tests/python/kaolin/render/spc/test_rayops.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+import kaolin.render.spc as spc_render
+
+class TestRaytrace:
+    @pytest.fixture(autouse=True)
+    def feats(self):
+        feats = torch.tensor([
+            [1,1],[1,1],[1,1],[2,2],[3,3],[5,5]
+            ],
+            device='cuda', dtype=torch.float)
+        return feats
+    
+    @pytest.fixture(autouse=True)
+    def feats_big(self):
+        feats = torch.rand([100000, 100, 32], device='cuda', dtype=torch.float)
+        return feats
+
+    @pytest.fixture(autouse=True)
+    def boundaries_big(self):
+        boundary = torch.zeros([100000, 100], device='cuda', dtype=torch.bool)
+        boundary[:, 0] = True
+        return boundary.reshape(-1)
+    
+    @pytest.fixture(autouse=True)
+    def tau(self):
+        feats = torch.tensor([
+            [0],[0],[0],[1],[0],[1]
+            ],
+            device='cuda', dtype=torch.float)
+        return feats
+
+    @pytest.fixture(autouse=True)
+    def boundaries(self):
+        boundary = torch.tensor([1,0,1,0,0,1], device='cuda', dtype=torch.bool)
+        return boundary
+
+    def test_mark_pack_boundary(self):
+        ridx = torch.tensor([1,1,1,1,2,2,3,3,3], device='cuda', dtype=torch.int)
+        
+        expected_boundary = torch.tensor([1,0,0,0,1,0,1,0,0], device='cuda', dtype=torch.bool)
+
+        output = spc_render.mark_pack_boundary(ridx)
+
+        assert torch.equal(output, expected_boundary)
+
+    def test_diff(self, feats, boundaries):
+        diff = spc_render.diff(feats, boundaries)
+        expected = torch.tensor([[0,0], [0,0], [1,1], [1,1], [0,0], [0,0]], device='cuda', dtype=torch.float)
+        assert torch.equal(diff, expected)
+
+    def test_sum_reduce(self, feats, boundaries):
+        sum_reduce = spc_render.sum_reduce(feats, boundaries)
+        expected = torch.tensor([[2,2], [6,6], [5,5]], device='cuda', dtype=torch.float)
+        assert torch.equal(sum_reduce, expected)
+
+    def test_sum_reduce_big(self, feats_big, boundaries_big):
+        fdim = feats_big.shape[-1]
+        sum_reduce = spc_render.sum_reduce(feats_big.reshape(-1, fdim), boundaries_big)
+        expected = feats_big.sum(1)
+        assert torch.allclose(sum_reduce, expected)
+    
+    def test_sum_reduce_big_backward(self, feats_big, boundaries_big):
+
+        feats_big.requires_grad = True
+        fdim = feats_big.shape[-1]
+
+        if feats_big.grad is not None:
+            feats_big.grad.detach_()
+            feats_big.grad.zero_()
+        sum_reduce = spc_render.sum_reduce(feats_big.reshape(-1, fdim), boundaries_big)
+        loss = sum_reduce.sum()
+        loss.backward()
+        grad0 = feats_big.grad.clone()
+
+        if feats_big.grad is not None:
+            feats_big.grad.detach_()
+            feats_big.grad.zero_()
+        expected = feats_big.sum(1)
+        loss = expected.sum()
+        loss.backward()
+        grad1 = feats_big.grad.clone()
+
+        assert torch.allclose(grad0, grad1)
+
+    def test_cumsum(self, feats, boundaries):
+        cumsum = spc_render.cumsum(feats, boundaries)
+        expected = torch.tensor([[1,1], [2,2], [1,1], [3,3], [6,6], [5,5]], device='cuda', dtype=torch.float)
+        assert torch.equal(cumsum, expected)
+    
+    def test_cumsum_big(self, feats_big, boundaries_big):
+        fdim = feats_big.shape[-1]
+        cumsum = spc_render.cumsum(feats_big.reshape(-1, fdim), boundaries_big)
+        expected = torch.cumsum(feats_big, dim=1).reshape(-1, fdim)
+        assert torch.allclose(cumsum, expected)
+
+    def test_cumsum_big_backward(self, feats_big, boundaries_big):
+
+        feats_big.requires_grad = True
+        fdim = feats_big.shape[-1]
+
+        if feats_big.grad is not None:
+            feats_big.grad.detach_()
+            feats_big.grad.zero_()
+        cumsum = spc_render.cumsum(feats_big.reshape(-1, fdim), boundaries_big)
+        loss = cumsum.sum()
+        loss.backward()
+        grad0 = feats_big.grad.clone()
+
+        if feats_big.grad is not None:
+            feats_big.grad.detach_()
+            feats_big.grad.zero_()
+        expected = torch.cumsum(feats_big, dim=1)
+        loss = expected.sum()
+        loss.backward()
+        grad1 = feats_big.grad.clone()
+
+        assert torch.allclose(grad0, grad1)
+
+    def test_cumsum_reverse(self, feats, boundaries):
+        cumsum = spc_render.cumsum(feats, boundaries, reverse=True)
+        expected = torch.tensor([[2,2], [1,1], [6,6], [5,5], [3,3], [5,5]], device='cuda', dtype=torch.float)
+        assert torch.equal(cumsum, expected)
+    
+    def test_cumsum_exclusive(self, feats, boundaries):
+        cumsum = spc_render.cumsum(feats, boundaries, reverse=False, exclusive=True)
+        expected = torch.tensor([[0,0], [1,1], [0,0], [1,1], [3,3], [0,0]], device='cuda', dtype=torch.float)
+        assert torch.equal(cumsum, expected)
+    
+    def test_cumsum_exclusive_reverse(self, feats, boundaries):
+        cumsum = spc_render.cumsum(feats, boundaries, reverse=True, exclusive=True)
+        expected = torch.tensor([[1,1], [0,0], [5,5], [3,3], [0,0], [0,0]], device='cuda', dtype=torch.float)
+        assert torch.equal(cumsum, expected)
+       
+    def test_cumprod(self, feats, boundaries):
+        cumprod = spc_render.cumprod(feats, boundaries)
+        expected = torch.tensor([[1,1], [1,1], [1,1], [2,2], [6,6], [5,5]], device='cuda', dtype=torch.float)
+        assert torch.equal(cumprod, expected)
+    
+    def test_cumprod_big(self, feats_big, boundaries_big):
+        fdim = feats_big.shape[-1]
+        cumprod = spc_render.cumprod(feats_big.reshape(-1, fdim), boundaries_big)
+        expected = torch.cumprod(feats_big, dim=1).reshape(-1, fdim)
+        assert torch.allclose(cumprod, expected)
+    
+    def test_cumprod_big_backward(self, feats_big, boundaries_big):
+
+        feats_big += 1e-7
+        feats_big.requires_grad = True
+        fdim = feats_big.shape[-1]
+
+        if feats_big.grad is not None:
+            feats_big.grad.detach_()
+            feats_big.grad.zero_()
+        cumprod = spc_render.cumprod(feats_big.reshape(-1, fdim), boundaries_big)
+        loss = cumprod.sum()
+        loss.backward()
+        grad0 = feats_big.grad.clone()
+
+        if feats_big.grad is not None:
+            feats_big.grad.detach_()
+            feats_big.grad.zero_()
+        expected = torch.cumprod(feats_big, dim=1)
+        loss = expected.sum()
+        loss.backward()
+        grad1 = feats_big.grad.clone()
+    
+        assert torch.allclose(grad0, grad1)
+
+    def test_cumprod_reverse(self, feats, boundaries):
+        cumprod = spc_render.cumprod(feats, boundaries, reverse=True)
+        expected = torch.tensor([[1,1], [1,1], [6,6], [6,6], [3,3], [5,5]], device='cuda', dtype=torch.float)
+        assert torch.equal(cumprod, expected)
+    
+    def test_cumprod_exclusive(self, feats, boundaries):
+        cumprod = spc_render.cumprod(feats, boundaries, reverse=False, exclusive=True)
+        expected = torch.tensor([[1,1], [1,1], [1,1], [1,1], [2,2], [1,1]], device='cuda', dtype=torch.float)
+        assert torch.equal(cumprod, expected)
+    
+    def test_cumprod_exclusive_reverse(self, feats, boundaries):
+        cumprod = spc_render.cumprod(feats, boundaries, reverse=True, exclusive=True)
+        expected = torch.tensor([[1,1], [1,1], [6,6], [3,3], [1,1], [1,1]], device='cuda', dtype=torch.float)
+        assert torch.equal(cumprod, expected)
+       
+    def test_exponential_integration(self, feats, tau, boundaries):
+        integrated_feats, transmittance = spc_render.exponential_integration(feats, tau, boundaries)
+        expected_feats = torch.tensor([[0,0], [0.4651,0.4651], [1.1627, 1.1627]], device='cuda', dtype=torch.float)
+        expected_transmittance = torch.tensor([[0.0],[0.0],[0.0],[0.2325],[0.0],[0.2325]], device='cuda', dtype=torch.float)
+        assert torch.allclose(integrated_feats, expected_feats, atol=1e-4)
+        assert torch.allclose(transmittance, expected_transmittance, atol=1e-4)
+
+


### PR DESCRIPTION
This commit addresses issue [!462. ](https://github.com/NVIDIAGameWorks/kaolin/issues/462).

This adds CUDA kernels and Kaolin functions for `diff`, `sum_reduce`, `cumsum`, `cumprod`, and `exponential_integration` which are all useful for performing differentiable rendering with Kaolin. 

