### PR TITLE
Change default option for exponential integration

### DIFF
--- a/kaolin/render/spc/raytrace.py
+++ b/kaolin/render/spc/raytrace.py
@@ -262,7 +262,7 @@ def cumprod(feats, boundaries, exclusive=False, reverse=False):
     """
     return Cumprod.apply(feats.contiguous(), boundaries.contiguous(), exclusive, reverse)
 
-def exponential_integration(feats, tau, boundaries, exclusive=False):
+def exponential_integration(feats, tau, boundaries, exclusive=True):
     r"""Exponential transmittance integration across packs using the optical thickness (tau).
 
     Exponential transmittance is derived from the Beer-Lambert law. Typical implementations of
@@ -278,7 +278,7 @@ def exponential_integration(feats, tau, boundaries, exclusive=False):
         boundaries (torch.BoolTensor): bools of shape :math:`(\text{num_rays})`.
             Given some index array marking the pack IDs, the boundaries can be calculated with
             :func:`mark_pack_boundaries`.
-        exclusive (bool): Compute exclusive exponential integration if true.
+        exclusive (bool): Compute exclusive exponential integration if true. (default: True)
 
     Returns:
         (torch.FloatTensor, torch.FloatTensor)

--- a/tests/python/kaolin/render/spc/test_rayops.py
+++ b/tests/python/kaolin/render/spc/test_rayops.py
@@ -199,7 +199,7 @@ class TestRaytrace:
         assert torch.equal(cumprod, expected)
        
     def test_exponential_integration(self, feats, tau, boundaries):
-        integrated_feats, transmittance = spc_render.exponential_integration(feats, tau, boundaries)
+        integrated_feats, transmittance = spc_render.exponential_integration(feats, tau, boundaries, exclusive=False)
         expected_feats = torch.tensor([[0,0], [0.4651,0.4651], [1.1627, 1.1627]], device='cuda', dtype=torch.float)
         expected_transmittance = torch.tensor([[0.0],[0.0],[0.0],[0.2325],[0.0],[0.2325]], device='cuda', dtype=torch.float)
         assert torch.allclose(integrated_feats, expected_feats, atol=1e-4)


### PR DESCRIPTION
Most normal purposes of exponential integration will use `exclusive=True`, so make that the default option.

