### PR TITLE
Loosen test precision tolerance

### DIFF
--- a/tests/python/kaolin/ops/spc/test_conv.py
+++ b/tests/python/kaolin/ops/spc/test_conv.py
@@ -152,17 +152,17 @@ class TestConv3D:
         expected_height, expected_width, expected_depth = expected_output.shape[2:]
         expected_output *= output_sparsity_masks[:, :, :expected_height, :expected_width, :expected_depth]
         assert torch.allclose(output[:, :, :expected_height, :expected_width, :expected_depth],
-                              expected_output, atol=1e-5, rtol=1e-5)
+                              expected_output, atol=1e-3, rtol=1e-3)
         grad_output = torch.rand_like(output)
         output.backward(grad_output)
         expected_output.backward(grad_output[:, :, :expected_height, :expected_width, :expected_depth])
 
         _, _, sparsified_grad = spc.feature_grids_to_spc(feature_grids.grad, sparsity_masks)
 
-        assert torch.allclose(coalescent_features.grad, sparsified_grad)
+        assert torch.allclose(coalescent_features.grad, sparsified_grad, rtol=1e-3, atol=1e-3)
         assert torch.allclose(spc_weight.grad,
                               dense_weight.grad.reshape(out_channels, in_channels, -1).permute(2, 1, 0),
-                              rtol=1e-3, atol=1e-3)
+                              rtol=5e-2, atol=5e-2)
 
     @pytest.mark.parametrize('with_spc_to_dict', [False, True])
     @pytest.mark.parametrize('jump', [0, 1, 2])
@@ -231,17 +231,17 @@ class TestConv3D:
                                            kernel_offset:depth + kernel_offset]
         expected_output *= out_sparsity_masks.unsqueeze(1)
         assert output_level == max_level
-        assert torch.allclose(output, expected_output, rtol=1e-5, atol=1e-5)
+        assert torch.allclose(output, expected_output, rtol=1e-3, atol=1e-3)
         # test backward
         grad_out = torch.rand_like(expected_output)
         expected_output.backward(grad_out)
         output.backward(grad_out)
         _, _, sparsified_grad = spc.feature_grids_to_spc(feature_grids.grad, sparsity_masks)
         assert torch.allclose(coalescent_features.grad, sparsified_grad,
-                              rtol=1e-5, atol=1e-5)
+                              rtol=5e-2, atol=5e-2)
         assert torch.allclose(spc_weight.grad,
                               dense_weight.grad.reshape(out_channels, in_channels, -1).permute(2, 1, 0),
-                              rtol=1e-3, atol=1e-3)
+                              rtol=5e-2, atol=5e-2)
 
     @pytest.mark.parametrize('with_spc_to_dict', [False, True])
     @pytest.mark.parametrize('jump', [0, 1, 2])

--- a/tests/python/kaolin/ops/test_gcn.py
+++ b/tests/python/kaolin/ops/test_gcn.py
@@ -159,15 +159,15 @@ class TestGraphConv(object):
 
     def test_gcn_sparse(self, device, gcn, adj, node_feat_in, expected):
         node_feat_out = gcn(node_feat_in, adj, normalize_adj=True)
-        assert torch.allclose(node_feat_out, expected)
+        assert torch.allclose(node_feat_out, expected, rtol=1e-3, atol=1e-3)
         adj = normalize_adj(adj)
         node_feat_out_2 = gcn(node_feat_in, adj, normalize_adj=False)
-        assert torch.allclose(node_feat_out, node_feat_out_2)
+        assert torch.allclose(node_feat_out, node_feat_out_2, rtol=1e-4, atol=1e-4)
 
     def test_gcn_dense(self, device, gcn, adj, node_feat_in, expected):
         dense_adj = torch.sparse.mm(adj, torch.eye(3, device=device))
         node_feat_out = gcn(node_feat_in, dense_adj, normalize_adj=True)
-        assert torch.allclose(node_feat_out, expected)
+        assert torch.allclose(node_feat_out, expected, rtol=1e-3, atol=1e-3)
         dense_adj = normalize_adj(dense_adj)
         node_feat_out_2 = gcn(node_feat_in, dense_adj, normalize_adj=False)
-        assert torch.allclose(node_feat_out, node_feat_out_2)
+        assert torch.allclose(node_feat_out, node_feat_out_2, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
Testing on RTX 3090 on windows fails with the current precision tolerance values. This MR loosens the minimal subset of tolerances to pass. Covers `test_conv.py` and `test_gcn.py` (adding new explicit tolerance thresholds).