### PR TITLE
Fix issues making gitlab CI fail

### DIFF
--- a/ci/gitlab_jenkins_templates/ubuntu_test_CI.jenkins
+++ b/ci/gitlab_jenkins_templates/ubuntu_test_CI.jenkins
@@ -31,6 +31,7 @@ spec:
         gitlabCommitStatus("test-${configName}-${arch}") {
           stage("Install deps") {
             sh 'pip install -r /kaolin/tools/ci_requirements.txt'
+            sh 'apt update && apt install -y unzip && unzip /kaolin/examples/samples/rendered_clock.zip -d /kaolin/examples/samples/'
           }
           testMap = [
             "Disp info": {
@@ -50,7 +51,6 @@ spec:
               }
             }, "DIB-R Tutorial": {
               stage("DIB-R Tutorial") {
-                sh 'apt update && apt install -y unzip && unzip /kaolin/examples/samples/rendered_clock.zip -d /kaolin/examples/samples/'
                 sh 'cd /kaolin/examples/tutorial && ipython dibr_tutorial.ipynb'
               }
             }, "DMTet Tutorial": {

--- a/kaolin/io/dataset.py
+++ b/kaolin/io/dataset.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020,21 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2020,21-22 NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -236,14 +236,18 @@ class ProcessedDataset(KaolinDataset):
                             self.cache_convert(key, data)
                 else:
                     p = Pool(num_workers)
-                    iterator = p.imap_unordered(
-                        _preprocess_task,
-                        [(idx, self._get_base_data, self.get_cache_key,
-                          self.cache_convert)
-                         for idx in uncached])
-                    for i in tqdm(range(len(uncached)), desc=desc,
-                                  disable=no_progress):
-                        next(iterator)
+                    try:
+                        iterator = p.imap_unordered(
+                            _preprocess_task,
+                            [(idx, self._get_base_data, self.get_cache_key,
+                              self.cache_convert)
+                             for idx in uncached])
+                        for i in tqdm(range(len(uncached)), desc=desc,
+                                      disable=no_progress):
+                            next(iterator)
+                    finally:
+                        p.close()
+                        p.join()
         else:
             self.cache_convert = None
 

--- a/kaolin/ops/conversions/voxelgrid.py
+++ b/kaolin/ops/conversions/voxelgrid.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2019,20 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019,20-22 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -112,7 +113,7 @@ def voxelgrids_to_cubic_meshes(voxelgrids, is_trimesh=True):
         voxelgrids = voxelgrids.float()
 
     conv_results = torch.nn.functional.conv3d(
-        voxelgrids, k, padding=1)  # (B, 3, r, r, r)
+        voxelgrids, k, padding=1).round()  # (B, 3, r, r, r)
 
     indices = torch.nonzero(conv_results.transpose(
         0, 1), as_tuple=True)  # (N, 5)


### PR DESCRIPTION
1) Pool should be closed after preprocessing dataset
2) Force rounding output of convolution for `VoxelgridsToCubicMeshes` as there are some issue Ampere with nvcr containers.
(Note: this is adding a little slowdown but should be negligible)
Signed-off-by: Clement Fuji Tsang <cfujitsang@nvidia.com>