### PR TITLE
fix: use elif in the displacement conditional

### DIFF
--- a/kaolin/io/materials.py
+++ b/kaolin/io/materials.py
@@ -745,7 +745,7 @@ class PBRMaterial(Material):
                     params['normals_texture'] = output * 2. - 1.
                     if 'colorspace' in data:
                         params['normals_colorspace'] = data['colorspace']['value']
-            if 'displacement':
+            elif 'displacement' in name.lower():
                 output, is_value = _read_data(data)
                 params[f'displacement_{["texture", "value"][is_value]}'] = output
                 if 'colorspace' in data:


### PR DESCRIPTION
In materials.py, the displacement check doesn't utilize name.lower() nor the rest of the branch logic in the _read_data function. Based on the rest of the if statements in the _read_data function, this is probably a mistake.