### PR TITLE
Fix bug in unbatched_query

### DIFF
--- a/kaolin/csrc/ops/spc/query_cuda.cu
+++ b/kaolin/csrc/ops/spc/query_cuda.cu
@@ -39,9 +39,9 @@ __global__ void query_cuda_kernel(
 
     for (int i=idx; i<n; i+=stride) {
         point_data point = make_point_data(
-            resolution * (query_coords[i*3 + 0] * 0.5 + 0.5),
-            resolution * (query_coords[i*3 + 1] * 0.5 + 0.5),
-            resolution * (query_coords[i*3 + 2] * 0.5 + 0.5)
+            floor(resolution * (query_coords[i*3 + 0] * 0.5 + 0.5)),
+            floor(resolution * (query_coords[i*3 + 1] * 0.5 + 0.5)),
+            floor(resolution * (query_coords[i*3 + 2] * 0.5 + 0.5))
         );
         pidx[i] = identify(point, level, prefix_sum, octree);
     }

--- a/tests/python/kaolin/ops/spc/test_spc.py
+++ b/tests/python/kaolin/ops/spc/test_spc.py
@@ -234,6 +234,25 @@ class TestQuery:
         assert torch.equal(point_hierarchy[results_float[:-2]], query_points[:-2])
         assert torch.equal(point_hierarchy[results_int[:-2]], query_points[:-2])
 
+    def test_query_flooredge(self):
+        points = torch.tensor(
+            [[0,0,0]], device='cuda', dtype=torch.short)
+        level = 1
+        octree = unbatched_points_to_octree(points, level)
+        length = torch.tensor([len(octree)], dtype=torch.int32)
+        _, pyramid, prefix = scan_octrees(octree, length)
+        query_coords = torch.tensor(
+            [[-3.0,-3.0,-3.0],
+             [-2.5,-2.5,-2.5],
+             [2.5,2.5,2.5],
+             [3.0,3.0,3.0],
+             [0.0,0.0,0.0],
+             [0.5,0.5,0.5]], device='cuda', dtype=torch.float)
+        results = unbatched_query(octree, prefix, query_coords, 0)
+        expected_results = torch.tensor(
+            [-1,-1,-1,-1,0,0], dtype=torch.long, device='cuda')
+        assert torch.equal(expected_results, results)
+
     def test_query_multiscale(self):
         points = torch.tensor(
             [[3,2,0],


### PR DESCRIPTION
Fix bug in unbatched_query where some points are spurriously classified as hitting the voxels.
Bug results from the round-towards-zero behaviour for casting.
