### PR TITLE
omitting R G B from .obj vertex data

### DIFF
--- a/kaolin/io/obj.py
+++ b/kaolin/io/obj.py
@@ -219,7 +219,7 @@ def import_mesh(path, with_materials=False, with_normals=False,
             if len(data) == 0:
                 continue
             if data[0] == 'v':
-                vertices.append(data[1:])
+                vertices.append(data[1:4])
             elif with_materials and data[0] == 'vt':
                 uvs.append(data[1:3])
             elif with_normals and data[0] == 'vn':


### PR DESCRIPTION
Wavefront .obj files support `v X Y Z R G B`, which get interpreted by `kaolin/io/obj.py:import_mesh` as additional vertices. This change omits the R G B values. 

Addresses the same issue as [this PR](https://github.com/NVIDIAGameWorks/kaolin/pull/300), but in a different way. 