### PR TITLE
Quaternion transformations.

### DIFF
--- a/examples/recipes/quat/quat_transforms.py
+++ b/examples/recipes/quat/quat_transforms.py
@@ -1,0 +1,53 @@
+# ==============================================================================================================
+# The following snippet demonstrates how to use the quaternion representation transforms
+# ==============================================================================================================
+
+import math
+import torch
+import numpy as np
+from kaolin.ops import quat
+
+device = 'cuda'
+
+# generate a batch of 2 identity quaternions
+identity = quat.quat_identity([2], device=device)
+
+# manually create a batch of 2 quaternions
+quats = torch.tensor([[2, 3, 4, 1], [0, -4, -2, -10]], device=device)
+print(quats)
+
+# multiply the two quaternions
+quats_mul = quat.quat_mul(identity, quats)
+print(quats_mul)
+
+# convert to 3x3 rotation matrix representation
+rot33 = quat.rot33_from_quat(quats)
+print(rot33)
+
+# convert to angle-axis representation
+angle, axis = quat.angle_axis_from_quat(quats)
+print(angle, axis)
+
+# convert the 3x3 rotation matrix to the matching angle-axis representation
+angle2, axis2 = quat.angle_axis_from_rot33(rot33)
+print(angle2, axis2)
+print(torch.allclose(angle, angle2))
+print(torch.allclose(axis, axis2))
+
+# convert to 4x4 rotation matrix
+rot44 = quat.rot44_from_quat(quats)
+print(rot44)
+
+# NOTE: there's plenty more conversions among these representations!
+
+# compose a Euclidean transform matrix of the quaternion rotation and a translation
+euclidean = quat.euclidean_from_rotation_translation(r=quats, t=torch.tensor([[1, 2, 3]]))
+print(euclidean)
+
+print(quat.euclidean_rotation_matrix(euclidean))  # get the rotation component
+print(quat.euclidean_translation_vector(euclidean))  # or the translation component
+
+# rotate a 3d point by the rotation represented by a tensor
+point = torch.tensor([[1, 2, 3]], device=device)
+quat_rot = quat.quat_rotate(quats, point)  # apply a batch of 2 rotations, represented by the two quats
+print(quat_rot)

--- a/kaolin/math/quat/__init__.py
+++ b/kaolin/math/quat/__init__.py
@@ -1,0 +1,7 @@
+from .angle_axis import *
+from .euclidean import *
+from .matrix44 import *
+from .quaternion import *
+from .rotation33 import *
+from .transform import *
+from .util import *

--- a/kaolin/math/quat/angle_axis.py
+++ b/kaolin/math/quat/angle_axis.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Tuple
+
+import torch
+from torch import Tensor
+
+from .quaternion import quat_from_rot33, quat_imaginary, quat_unit_positive, quat_real
+
+### CONVERSIONS ###
+
+
+@torch.jit.script
+def angle_axis_from_quat(quat: Tensor) -> Tuple[Tensor, Tensor]:
+    """Convert a rotation quaternion to (angle, axis) representation.
+
+    The axis is normalized to unit length.
+
+    The angle is guaranteed to be between [0, pi], while axis may be positive or negative.
+
+    Args:
+        quat (Tensor): Rotation quaternion of shape (b, 4).
+
+    Returns:
+        Tuple[Tensor, Tensor]: Angle in radians of shape (b, 1) and axis of shape (b, 3).
+    """
+    EPS = 1.1920928955078125e-07  # from _get_eps. cannot be compiled
+
+    q = quat_unit_positive(quat)
+    q += EPS
+    xyz = quat_imaginary(q)
+    w = quat_real(q)
+    norm = xyz.norm(p=2, dim=-1, keepdim=True)
+    angle = 2 * torch.atan2(norm, w.abs())
+    axis = w.sign() * (xyz / norm)
+    return angle, axis
+
+
+@torch.jit.script
+def angle_axis_from_rot33(mat: Tensor) -> Tuple[Tensor, Tensor]:
+    """Convert a 3x3 rotation matrix to (angle, axis) representation.
+
+    Args:
+        mat (Tensor): Rotation matrix of shape (b, 3, 3).
+
+    Returns:
+        Tuple[Tensor, Tensor]: Angle in radians of shape (b,1) and axis of shape (b,3).
+    """
+    quat = quat_from_rot33(mat)
+    return angle_axis_from_quat(quat)

--- a/kaolin/math/quat/euclidean.py
+++ b/kaolin/math/quat/euclidean.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+from .matrix44 import rot44_from_quat
+from .rotation33 import is_rot33_valid, rot33_inverse
+
+### CONVERSIONS ###
+
+
+@torch.jit.script
+def euclidean_identity(batch_size: int, device: torch.device = "cuda") -> Tensor:
+    """Identity Euclidean transformation for given batch size.
+
+    Args:
+        batch_size (int): Batch size.
+        device (torch.device, optional): Device memory to use. Defaults to "cuda".
+
+    Returns:
+        Tensor: Batch of identity Euclidean transforms of shape (b, 4, 4).
+    """
+    return torch.eye(4, device=device).repeat((batch_size, 1, 1))
+
+
+@torch.jit.script
+def euclidean_from_rotation_translation(r: Optional[Tensor] = None, t: Optional[Tensor] = None) -> Tensor:
+    """Construct a Euclidean transformation matrix from a rotation quaternion and 3d translation.
+
+    Only one of rotation and translation can be None.
+
+    Args:
+        r (Optional[Tensor], optional): Rotation quaternion of shape (b, 4). Defaults to None.
+        t (Optional[Tensor], optional): 3d translation vector of shape (b, 3). Defaults to None.
+
+    Returns:
+        Tensor: Euclidean transformation matrix.
+    """
+    assert r is not None or t is not None, "rotation and translation can't be all None"
+    if r is None:
+        # have translation
+        assert t is not None
+        r2 = euclidean_identity(t.shape[0], device=t.device)
+        r2[..., :3, 3] = t
+    elif t is None:
+        # have rotation
+        assert r is not None
+        r2 = rot44_from_quat(r)
+    else:
+        r2 = rot44_from_quat(r)
+        r2[..., :3, 3] = t
+    return r2
+
+
+### OPERATORS ###
+
+
+@torch.jit.script
+def euclidean_rotation_matrix(x: Tensor) -> Tensor:
+    """Retrieve 3d rotation matrix from Euclidean transformation matrix.
+
+    Args:
+        x (Tensor): Euclidean transformation matrices of shape (b, 4, 4).
+
+    Returns:
+        Tensor: 3d rotation matrices of shape (b, 3, 3)
+    """
+    return x[..., :3, :3]
+
+
+@torch.jit.script
+def euclidean_translation_vector(x: Tensor) -> Tensor:
+    """Retrieve the 3d translation vector from the Euclidean transformation matrix.
+
+    Args:
+        x (Tensor): Euclidean transformation matrices of shape (b, 4, 4).
+
+    Returns:
+        Tensor: 3d translation vectors of shape (b, 3)
+    """
+    return x[..., :3, 3]
+
+
+@torch.jit.script
+def is_euclidean_valid(x: Tensor, throw: bool = False) -> bool:
+    """Check whether a matrix represents a valid Euclidean transformation matrix.
+
+    Args:
+        x (Tensor): Euclidean transformation matrices of shape (b, 4, 4).
+
+    Returns:
+        bool: True if all are valid, False otherwise.
+    """
+    rot33 = euclidean_rotation_matrix(x)  # check 3d-rotation matrix
+    rot_valid = is_rot33_valid(rot33)
+    row_valid = bool((x[..., 3, :3] == 0).all())
+    col_valid = bool((x[..., 3, 3] == 1).all())
+    out = rot_valid and row_valid and col_valid
+    if throw and not out:
+        raise ValueError(f"Matrix {x} is not a valid Euclidean transformation matrix.\n\tRotation valid? {rot_valid}\n\tRows valid? {row_valid}.\n\tColumns valid? {col_valid}")
+    return out
+
+
+@torch.jit.script
+def euclidean_inverse(x: Tensor) -> Tensor:
+    """Inverse of a Euclidean transformation matrix.
+
+    Rotation is inverted by :math:`R \\rightarrow R^{-1} = R^{T}`.
+
+    Translation is inverted by :math:`T \\rightarrow -R^{-1}T`.
+
+    The resulting matrix is of the form:
+    :math:`\\left[\\begin{array}{cccc}
+    R^{-1}&T^{-1}\\\\
+    \\textbf{0}&\\textbf{1}\\\\
+    \\end{array}\\right]`
+
+    Args:
+        x (Tensor): Euclidean transformation matrices of shape (b, 4, 4).
+
+    Returns:
+        Tensor: Inverted matrices of shape (b, 4, 4).
+    """
+    inv_rot = rot33_inverse(euclidean_rotation_matrix(x))
+    inv_trans = -inv_rot @ euclidean_translation_vector(x).squeeze()
+    mat = torch.zeros_like(x, device=x.device)
+    mat[..., :3, :3] = inv_rot
+    mat[..., :3, 3] = inv_trans
+    mat[..., 3, 3] = 1
+    return mat

--- a/kaolin/math/quat/matrix44.py
+++ b/kaolin/math/quat/matrix44.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from torch import Tensor
+
+from .rotation33 import rot33_from_quat
+from .util import pad_mat33_to_mat44
+
+### CONVERSIONS ###
+
+
+@torch.jit.script
+def rot44_from_quat(quat: Tensor) -> Tensor:
+    """Convert a rotation quaternion to a 4x4 rotation matrix.
+
+    Args:
+        quat (Tensor): Rotation quaternion of shape (b, 4).
+
+    Returns:
+        Tensor: 4x4 rotation matrix of shape (b, 4, 4).
+    """
+    mat33 = rot33_from_quat(quat)
+    return pad_mat33_to_mat44(mat33)
+
+
+@torch.jit.script
+def translation_to_mat44(vec: Tensor) -> torch.Tensor:
+    """Generate an identity 4x4 matrix with translation set.
+
+    Args:
+        vec (Tensor): 3d translation vector of shape (b, 4). Ignores the last dimension (4th) of the vector.
+
+    Returns:
+        torch.Tensor: 4x4 identity matrix with provided translation of shape (b, 4, 4).
+    """
+    if vec.ndim < 2:
+        vec = vec.unsqueeze(0)  # pad batch
+    mat = torch.eye(4, 4, device=vec.device, dtype=torch.float).repeat((vec.shape[0], 1, 1))
+    mat[..., :3, -1] = vec[..., :3]
+
+    return mat
+
+
+@torch.jit.script
+def scale_to_mat44(scale: Tensor) -> torch.Tensor:
+    """Generate a 4x4 matrix scaled to the provided scale.
+
+    Args:
+        scale (Tensor): 3d scaling vector of shape (b, 3).
+
+    Returns:
+        torch.Tensor: 4x4 matrix with provided scaling of shape (b, 4, 4).
+    """
+    if scale.ndim < 2:
+        scale = scale.unsqueeze(0)  # pad batch
+    mat = torch.eye(4, 4, device=scale.device, dtype=torch.float).repeat((scale.shape[0], 1, 1))
+    mat[..., :3, :3] *= scale[..., :3].unsqueeze(-1)
+
+    return mat

--- a/kaolin/math/quat/quaternion.py
+++ b/kaolin/math/quat/quaternion.py
@@ -1,0 +1,305 @@
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+import torch
+from torch import Tensor
+
+### OPERATORS ###
+
+
+@torch.jit.script
+def quat_real(quat: Tensor) -> Tensor:
+    """Get the real component (`w`) of the quaternion.
+
+    Args:
+        quat (Tensor): Quaternion of shape (b, 4).
+
+    Returns:
+        Tensor: Real valued component of the quanternion of shape (b, 1).
+    """
+    return quat[..., 3:]
+
+
+@torch.jit.script
+def quat_imaginary(quat: Tensor) -> Tensor:
+    """Get the imaginary components (`xyz`) of the quaternion.
+
+    Args:
+        quat (Tensor): Quaternion of shape (b, 4).
+
+    Returns:
+        Tensor: Imaginary components of the quanternion of shape (b, 3).
+    """
+    return quat[..., :3]
+
+
+@torch.jit.script
+def quat_positive(quat: Tensor) -> Tensor:
+    """Generate a quanternion with positive real component.
+
+    Args:
+        quat (Tensor): Quaternion of shape (b, 4).
+
+    Returns:
+        Tensor: Quaternion with positive real components of shape (b, 4).
+    """
+    q = quat
+    z = (q[..., 3:] < 0).float()
+    q = (1 - 2 * z) * q
+    return q
+
+
+@torch.jit.script
+def quat_abs(quat: Tensor) -> Tensor:
+    """Compute the L2 norm of a quaternion.
+
+    Args:
+        quat (Tensor): Quaternion of shape (b, 4).
+
+    Returns:
+        Tensor: Quaternion norm value of shape (b).
+    """
+    return quat.norm(p=2, dim=-1)
+
+
+@torch.jit.script
+def quat_unit(quat: Tensor) -> Tensor:
+    """Normalize quaternion to have norm of 1.
+
+    Args:
+        quat (Tensor): Quaternion of shape (b, 4).
+
+    Returns:
+        Tensor: Normalized quaternion with norm of 1 of shape (b, 4).
+    """
+    return torch.nn.functional.normalize(quat, p=2., dim=-1)
+
+
+@torch.jit.script
+def quat_unit_positive(quat: Tensor) -> Tensor:
+    """Normalize quaternion to be a valid 3d rotation.
+
+    Forces the quaternion to have a norm of 1 and positive real component.
+
+    Args:
+        quat (Tensor): Quaternion of shape (b, 4).
+
+    Returns:
+        Tensor: Rotation quaternion of shape (b, 4).
+    """
+    return quat_unit(quat_positive(quat))  # normalized to positive and unit quaternion
+
+
+@torch.jit.script
+def quat_identity(shape: List[int], device: torch.device = "cuda") -> Tensor:
+    """Generate a batch of identity quaternions.
+
+    Args:
+        shape (List[int]): Batch shape to generate.
+        device (torch.device, optional): Device memory to use. Defaults to "cuda".
+
+    Returns:
+        Tensor: Identity quaternion of shape (`shape`, 4).
+    """
+    w = torch.ones(shape + [1], device=device)
+    xyz = torch.zeros(shape + [3], device=device)
+    q = torch.cat([xyz, w], dim=-1)
+    return quat_unit_positive(q)
+
+
+@torch.jit.script
+def quat_conjugate(quat: Tensor) -> Tensor:
+    """Generate conjugate quaternion. Imaginary components are negated.
+
+    Args:
+        quat (Tensor): Quaternion of shape (b, 4).
+
+    Returns:
+        Tensor: Conjugate quaternion of shape (b, 4).
+    """
+    return torch.cat([-quat_imaginary(quat), quat_real(quat)], dim=-1)
+
+
+@torch.jit.script
+def quat_inverse(quat: Tensor) -> Tensor:
+    """Invert a unit rotation quaternion.
+
+    Same as conjugating a quaternion.
+
+    Args:
+        quat (Tensor): Quaternion of shape (b, 4).
+
+    Returns:
+        Tensor: Inverted quaternion of shape (b, 4).
+    """
+    return quat_conjugate(quat)
+
+
+@torch.jit.script
+def quat_mul(a: Tensor, b: Tensor) -> Tensor:
+    """Multiply two quaternions.
+
+    Args:
+        a (Tensor): First quaternion of shape (b, 4).
+        b (Tensor): Second quaternion of shape (b, 4).
+
+    Returns:
+        Tensor: Multiplication resulting quaternion of shape (b, 4).
+    """
+    x1, y1, z1, w1 = a.unbind(-1)
+    x2, y2, z2, w2 = b.unbind(-1)
+
+    w = w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2
+    x = w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2
+    y = w1 * y2 + y1 * w2 + z1 * x2 - x1 * z2
+    z = w1 * z2 + z1 * w2 + x1 * y2 - y1 * x2
+
+    return torch.stack([x, y, z, w], dim=-1)
+
+
+@torch.jit.script
+def quat_rotate(rotation: Tensor, point: Tensor) -> Tensor:
+    """Rotate a 3d point by a rotation quaternion.
+
+    Args:
+        rotation (Tensor): Rotation quaternion of shape (b, 4).
+        point (Tensor): Point to rotate of shape (b, 3).
+
+    Returns:
+        Tensor: Rotated point of shape (b, 3).
+    """
+    point_quat = torch.nn.functional.pad(point, (0, 1))
+    return quat_imaginary(quat_mul(quat_mul(rotation, point_quat), quat_conjugate(rotation)))
+
+
+### CONVERSIONS ###
+
+
+@torch.jit.script
+def quat_from_angle_axis(angle: Tensor, axis: Tensor, is_degree: bool = False):
+    """Convert an (angle, axis) representation to rotation quaternion representation.
+
+    Args:
+        angle (Tensor): Angle in radians of shape (b, 1).
+        axis (Tensor): Axis of rotation of shape (b, 3).
+
+    Returns:
+        Tensor: Rotation quaternion of shape (b, 4).
+    """
+    radians = torch.deg2rad(angle) if is_degree else angle
+    half_angle = 0.5 * radians
+    axis_norm = torch.nn.functional.normalize(axis, p=2., dim=-1)
+    w = half_angle.cos()
+    xyz = half_angle.sin() * axis_norm
+    return torch.hstack([xyz, w])
+
+
+@torch.jit.script
+def _safe_division(a, b) -> Tensor:
+    """Safe implementation of dividing a by b to mitigate small numerical values.
+
+    Args:
+        a (Tensor): Numerator tensor.
+        b (Tensor): Denominator tensor.
+
+    Returns:
+        Tensor: Result of dividing a by b (= a/b).
+    """
+    # values taken from `torch.finfo(dtype).eps`
+    #   workaround due to torchscript being unable to compile `finfo` method
+    EPS = 0.0
+    if b.dtype == torch.float16:
+        EPS = 0.0009765625
+    elif b.dtype == torch.float32:
+        EPS = 1.1920928955078125e-07
+    elif b.dtype == torch.float64:
+        EPS = 2.220446049250313e-16
+    return a / (b + EPS)
+
+
+@torch.jit.script
+def _tr_positive(trace: Tensor, entries: List[List[Tensor]]) -> Tensor:
+    sq = _safe_division(torch.tensor(0.5), torch.sqrt(trace + 1.0))
+    qx = (entries[2][1] - entries[1][2]) * sq
+    qy = (entries[0][2] - entries[2][0]) * sq
+    qz = (entries[1][0] - entries[0][1]) * sq
+    qw = 0.25 / sq
+    return torch.stack([qx, qy, qz, qw], dim=-1)
+
+
+@torch.jit.script
+def _case1(entries: List[List[Tensor]]) -> Tensor:
+    sq = 2.0 * torch.sqrt(1.0 + entries[0][0] - entries[1][1] - entries[2][2])
+    qx = 0.25 * sq
+    qy = _safe_division(entries[0][1] + entries[1][0], sq)
+    qz = _safe_division(entries[0][2] + entries[2][0], sq)
+    qw = _safe_division(entries[2][1] - entries[1][2], sq)
+    return torch.stack([qx, qy, qz, qw], dim=-1)
+
+
+@torch.jit.script
+def _case2(entries: List[List[Tensor]]) -> Tensor:
+    sq = 2.0 * torch.sqrt(1.0 + entries[1][1] - entries[0][0] - entries[2][2])
+    qx = _safe_division(entries[0][1] + entries[1][0], sq)
+    qy = 0.25 * sq
+    qz = _safe_division(entries[1][2] + entries[2][1], sq)
+    qw = _safe_division(entries[0][2] - entries[2][0], sq)
+    return torch.stack([qx, qy, qz, qw], dim=-1)
+
+
+@torch.jit.script
+def _case3(entries: List[List[Tensor]]) -> Tensor:
+    sq = 2.0 * torch.sqrt(1.0 + entries[2][2] - entries[0][0] - entries[1][1])
+    qx = _safe_division(entries[0][2] + entries[2][0], sq)
+    qy = _safe_division(entries[1][2] + entries[2][1], sq)
+    qz = 0.25 * sq
+    qw = _safe_division(entries[1][0] - entries[0][1], sq)
+    return torch.stack([qx, qy, qz, qw], dim=-1)
+
+
+@torch.jit.script
+def _case_indices(mat: Tensor, case: Tensor) -> Tensor:
+    c = case.unsqueeze(-1)
+    newdim = [mat.ndim - 2] + [4]  # reshape (a0, a1, ..., 3, 3) -> (a0, a1, ..., 4)
+    return c.tile(newdim)
+
+
+@torch.jit.script
+def quat_from_rot33(mat: Tensor) -> Tensor:
+    """Convert a 3x3 rotation matrix to rotation quaternion representation.
+
+    Args:
+        mat (Tensor): Rotation matrix of shape (b, 3, 3).
+
+    Returns:
+        Tensor: Rotation quaternion of shape (b, 4).
+    """
+    assert mat.shape[-1] == 3
+    assert mat.shape[-2] == 3
+
+    trace = torch.diagonal(mat, dim1=-1, dim2=-2).sum(dim=-1)
+    rows = torch.unbind(mat, dim=-2)
+    entries = [torch.unbind(row, dim=-1) for row in rows]
+
+    res2 = torch.where(_case_indices(mat, entries[1][1] > entries[2][2]), _case2(entries), _case3(entries))
+    res1 = torch.where(
+        _case_indices(mat, (entries[0][0] > entries[1][1]) & (entries[0][0] > entries[2][2])),
+        _case1(entries),
+        res2,
+    )
+    quat = torch.where(_case_indices(mat, trace > 0), _tr_positive(trace, entries), res1)
+    return quat

--- a/kaolin/math/quat/rotation33.py
+++ b/kaolin/math/quat/rotation33.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+import torch
+from torch import Tensor
+
+from .util import vector_normalize
+
+
+@torch.jit.script
+def is_rot33_valid(rot33: Tensor, atol: float = 1e-6) -> bool:
+    """Checks whether a 3x3 rotation matrix is valid.
+
+    Valid rotation matrices have determinant 1 and are orthogonal.
+
+    Args:
+        rot33 (Tensor): Rotation matrix of shape (b, 3, 3).
+        atol (float, optional): Absolute error tolerance for orthogonality check. Defaults to 1e-6.
+
+    Returns:
+        bool: True if the rotation is valid, False otherwise.
+    """
+    assert rot33.shape[-1] == rot33.shape[-2], f"invalid rotation matrix: expected square, but got {rot33.shape[-2:]}"
+
+    det = torch.linalg.det(rot33)
+    is_det_valid = torch.allclose(det, torch.ones(size=[1], device=det.device))
+
+    # Q^T Q = I  for orthogonal matrix
+    # create identity for DxD of last dimension only.
+    #   works because assuming square rotation matrix
+    identity = torch.eye(rot33.shape[-1], device=rot33.device)
+
+    # transpose matrix of last 2 dimensions only
+    ndim = rot33.dim()
+    perm_idx = list(range(ndim - 2)) + [ndim - 1, ndim - 2]
+    permutation = rot33.permute(perm_idx)
+    norm = rot33 @ permutation
+    is_orthogonal = torch.allclose(norm, identity, atol=atol)
+    return is_det_valid and is_orthogonal
+
+
+@torch.jit.script
+def rot33_identity(batch_size: int = 1, device: torch.device = "cuda") -> Tensor:
+    """Generate a batch of identity 3x3 rotation matrices.
+
+    Args:
+        batch_size (int, optional): Number of rotation matrices in the batch. Defaults to 1.
+        device (torch.device, optional): Device memory to use. Defaults to "cuda".
+
+    Returns:
+        Tensor: Batch of identity rotation matrices of shape (b, 3, 3).
+    """
+    return torch.eye(3, 3, device=device, dtype=torch.float).repeat((batch_size, 1, 1))
+
+
+@torch.jit.script
+def translation_identity(batch_size: int = 1, device: torch.device = "cuda") -> Tensor:
+    """Generate a batch of identity 3d translation vectors.
+
+    Args:
+        batch_size (int, optional): Number of translation vectors in the batch. Defaults to 1.
+        device (torch.device, optional): Device memory to use. Defaults to "cuda".
+
+    Returns:
+        Tensor: Batch of identity translation vectors of shape (b, 3).
+    """
+    return torch.zeros((batch_size, 3), dtype=torch.float, device=device)
+
+
+@torch.jit.script
+def rot33_inverse(mat: Tensor) -> Tensor:
+    """Invert a 3x3 rotation matrix.
+
+    Args:
+        mat (Tensor): Batch of 3x3 rotation matrices of shape (b, 3, 3).
+
+    Returns:
+        Tensor: Batch of inverted 3x3 rotation matrices of shape (b, 3, 3).
+    """
+    return mat.permute((0, 2, 1))
+
+
+@torch.jit.script
+def rot33_rotate(point: Tensor, mat: Tensor) -> Tensor:
+    """Rotate a point using a 3x3 rotation matrix.
+
+    Args:
+        point (Tensor): Batch of points to rotate of shape (b, 3).
+        mat (Tensor): Batch of 3x3 rotation matrices of shape (b, 3, 3).
+
+    Returns:
+        Tensor: Batch of rotated points of shape (b, 3).
+    """
+    return torch.matmul(mat, point.unsqueeze(-1)).squeeze()  # align batch sizes by appending dummy dimension
+
+
+### CONVERSIONS ###
+
+
+@torch.jit.script
+def rot33_from_quat(quat: Tensor) -> Tensor:
+    """Convert a rotation quaternion to 3x3 rotation matrix representation.
+
+    Args:
+        quat (Tensor): Rotation quaternion of shape (b, 4).
+
+    Returns:
+        Tensor: Batch of 3x3 rotation matrices of shape (b, 3, 3).
+    """
+    q = vector_normalize(quat)
+
+    x, y, z, w = q[..., 0], q[..., 1], q[..., 2], q[..., 3]
+
+    # Set individual elements
+    tx = 2.0 * x
+    ty = 2.0 * y
+    tz = 2.0 * z
+    twx = tx * w
+    twy = ty * w
+    twz = tz * w
+    txx = tx * x
+    txy = ty * x
+    txz = tz * x
+    tyy = ty * y
+    tyz = tz * y
+    tzz = tz * z
+
+    r0 = torch.stack([1.0 - (tyy + tzz), txy - twz, txz + twy], dim=-1)
+    r1 = torch.stack([txy + twz, 1.0 - (txx + tzz), tyz - twx], dim=-1)
+    r2 = torch.stack([txz - twy, tyz + twx, 1.0 - (txx + tyy)], dim=-1)
+
+    matrix = torch.stack([r0, r1, r2], dim=-2)
+    return matrix
+
+
+@torch.jit.script
+def rot33_from_angle_axis(angle: Tensor, axis: Tensor) -> Tensor:
+    """Convert an (angle, axis) representation to 3x3 rotation matrix representation.
+
+    Args:
+        angle (Tensor): Angle in radians of shape (b, 1).
+        axis (Tensor): Axis of rotation of shape (b, 3).
+
+    Returns:
+        Tensor: Batch of 3x3 rotation matrices of shape (b, 3, 3).
+    """
+    # pad out to batching dimensions
+    while angle.ndim < 2:
+        angle = angle.unsqueeze(0)
+    while axis.ndim < 2:
+        axis = axis.unsqueeze(0)
+
+    sin_axis = angle.sin() * axis
+    cos_angle = angle.cos()
+    cos1_axis = (1.0 - cos_angle) * axis
+    _, axis_y, axis_z = axis.unbind(-1)
+    cos1_axis_x, cos1_axis_y, _ = cos1_axis.unbind(-1)
+    sin_axis_x, sin_axis_y, sin_axis_z = sin_axis.unbind(-1)
+    c1axy = cos1_axis_x * axis_y
+    m01 = c1axy - sin_axis_z
+    m10 = c1axy + sin_axis_z
+    c1axz = cos1_axis_x * axis_z
+    m02 = c1axz + sin_axis_y
+    m20 = c1axz - sin_axis_y
+    c1ayz = cos1_axis_y * axis_z
+    m12 = c1ayz - sin_axis_x
+    m21 = c1ayz + sin_axis_x
+    diag = cos1_axis * axis + cos_angle
+    diag_x, diag_y, diag_z = diag.unbind(-1)
+    matrix = torch.stack([
+        torch.stack([diag_x, m01, m02], dim=-1),
+        torch.stack([m10, diag_y, m12], dim=-1),
+        torch.stack([m20, m21, diag_z], dim=-1)
+    ], dim=-2)
+    return matrix

--- a/kaolin/math/quat/transform.py
+++ b/kaolin/math/quat/transform.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Optional
+
+import torch
+from torch import Tensor
+
+from .euclidean import euclidean_rotation_matrix, euclidean_translation_vector
+from .quaternion import (
+    quat_from_rot33,
+    quat_identity,
+    quat_inverse,
+    quat_mul,
+    quat_unit_positive,
+    quat_rotate,
+)
+from .rotation33 import translation_identity
+
+### CONVERSIONS ###
+
+
+@torch.jit.script
+def transform_from_rotation_translation(
+    rotation: Optional[Tensor] = None, translation: Optional[Tensor] = None
+) -> Tensor:
+    """Generate a position-quaternion transform from a rotation quaternion and 3d translation.
+
+    Only one argument can be None.
+
+    Args:
+        r (Optional[Tensor], optional): Rotation quaternion of shape (b, 4). Defaults to None.
+        t (Optional[Tensor], optional): 3d translation vector of shape (b, 3). Defaults to None.
+
+    Returns:
+        Tensor: Position-quaternion transform of shape (b, 7).
+    """
+    assert rotation is not None or translation is not None, "rotation and translation can't be all None"
+    if rotation is None:
+        assert translation is not None
+        rotation = quat_identity(list(translation.shape), device=translation.device)
+    if translation is None:
+        translation = translation_identity(rotation.shape[0], device=rotation.device)
+    return torch.cat([rotation, translation], dim=-1)
+
+
+@torch.jit.script
+def transform_from_euclidean(euclidean: Tensor) -> Tensor:
+    """Convert a Euclidean transformation matrix to position-quaternion transform representation.
+
+    Args:
+        euclidean (Tensor): Euclidean transformation matrices of shape (b, 4, 4).
+
+    Returns:
+        Tensor: Position-quaternion transform of shape (b, 7).
+    """
+    return transform_from_rotation_translation(
+        rotation=quat_from_rot33(euclidean_rotation_matrix(euclidean)),
+        translation=euclidean_translation_vector(euclidean),
+    )
+
+
+### OPERATORS ###
+
+
+@torch.jit.script
+def transform_identity(shape: List[int], device: torch.device = "cuda") -> Tensor:
+    """Generate a batch of identity position-quaternion transforms.
+
+    Args:
+        shape (List[int]): Batch shape to generate.
+        device (torch.device, optional): Device memory to use. Defaults to "cuda".
+
+    Returns:
+        Tensor: Identity position-quaternion transform of shape (`shape`, 7).
+    """
+    r = quat_identity(shape, device=device)
+    t = torch.zeros(shape + [3], device=device)
+    return transform_from_rotation_translation(r, t)
+
+
+@torch.jit.script
+def transform_rotation(x: Tensor) -> Tensor:
+    """Retrieve the rotation component of a position-rotation transform.
+
+    Args:
+        x (Tensor): Position-quaternion transform of shape (b, 7).
+
+    Returns:
+        Tensor: Rotation quaternion of shape (b, 4).
+    """
+    return x[..., :4]
+
+
+@torch.jit.script
+def transform_translation(x: Tensor) -> Tensor:
+    """Retrieve the translation component of a position-rotation transform.
+
+    Args:
+        x (Tensor): Position-quaternion transform of shape (b, 7).
+
+    Returns:
+        Tensor: 3d translation vector of shape (b, 3).
+    """
+    return x[..., 4:]
+
+
+@torch.jit.script
+def transform_inverse(x: Tensor) -> Tensor:
+    """Invert a position-quaternion transform.
+
+    Args:
+        x (Tensor): Position-quaternion transform of shape (b, 7).
+
+    Returns:
+        Tensor: Inverted position-quaternion transform of shape (b, 7).
+    """
+    inv_rot = quat_inverse(transform_rotation(x))
+    return transform_from_rotation_translation(
+        rotation=inv_rot, translation=quat_rotate(inv_rot, -transform_translation(x))
+    )
+
+
+@torch.jit.script
+def transform_mul(x: Tensor, y: Tensor) -> Tensor:
+    """Combined two position-quaternion transforms.
+
+    Args:
+        x (Tensor): First position-quaternion transform of shape (b, 7).
+        y (Tensor): Second position-quaternion transform of shape (b, 7).
+
+    Returns:
+        Tensor: Combined position-quaternion transform of shape (b, 7).
+    """
+    r = quat_unit_positive(quat_mul(transform_rotation(x), transform_rotation(y)))
+    t = quat_rotate(transform_rotation(x), transform_translation(y)) + transform_translation(x)
+    return transform_from_rotation_translation(
+        rotation=r,
+        translation=t,
+    )
+
+
+@torch.jit.script
+def transform_apply(transform: Tensor, point: Tensor) -> Tensor:
+    """Apply a position-quaternion transform to a 3d point.
+
+    Args:
+        transform (Tensor): Position-quaternion transform of shape (b, 7).
+        point (Tensor): 3d point of shape (b, 3).
+
+    Returns:
+        Tensor: Transformed 3d point of shape (b, 3).
+    """
+    return quat_rotate(transform_rotation(transform), point) + transform_translation(transform)

--- a/kaolin/math/quat/util.py
+++ b/kaolin/math/quat/util.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from torch import Tensor
+
+
+def _get_eps(x: Tensor) -> float:
+    return torch.finfo(x.dtype).eps
+
+
+def to_torch(x, dtype=torch.float, device="cuda:0", requires_grad=False):
+    return torch.tensor(x, dtype=dtype, device=device, requires_grad=requires_grad)
+
+
+@torch.jit.script
+def vector_normalize(vec: Tensor) -> Tensor:
+    """Generate a normalized version of a batch of vectors.
+
+    Input is **NOT** modified in place.
+
+    Args:
+        vec (Tensor): Batch of Nd vectors of shape (b, N).
+
+    Returns:
+        Tensor: Batch of normalized Nd vectors of shape (b, N).
+    """
+    return (vec.T / torch.sqrt(torch.sum(vec ** 2, dim=-1))).T
+
+
+@torch.jit.script
+def pad_mat33_to_mat44(mat33: Tensor) -> Tensor:
+    """Pad a 3x3 rotation matrix to equivalent 4x4 rotation matrix.
+
+    Given input matrix :math:`R`, the output is:
+    :math:`\\left[\\begin{array}{cc}
+    R&\\textbf{0}\\\\
+    \\textbf{0}&\\textbf{1}\\\\
+    \\end{array}\\right]`
+
+    Args:
+        mat33 (Tensor): Batch of 3x3 rotation matices of shape (b, 3, 3).
+
+    Returns:
+        Tensor: Batch of 4x4 rotation matrices of shape (b, 4, 4).
+    """
+    mat44 = torch.nn.functional.pad(mat33, (0, 1, 0, 1), value=0.0)
+    mat44[..., 3, 3] = 1
+    return mat44
+
+
+def check_close(a: Tensor, b: Tensor, rtol=1e-5, atol=1e-8):
+    assert a.device == b.device
+    assert a.requires_grad == b.requires_grad
+    assert torch.allclose(a, b, rtol=rtol, atol=atol)

--- a/tests/python/kaolin/math/quat/test_euclidean.py
+++ b/tests/python/kaolin/math/quat/test_euclidean.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import pytest
+import torch
+from torch import Tensor
+
+torch.backends.cuda.matmul.allow_tf32 = False
+torch.backends.cudnn.allow_tf32 = False
+torch.set_printoptions(precision=8)
+
+from kaolin.math.quat.euclidean import (
+    euclidean_from_rotation_translation,
+    euclidean_inverse,
+    is_euclidean_valid,
+)
+
+euclidean_is_valid = [
+    [
+        torch.tensor(
+            [
+                [
+                    [-0.8571429, 0.2857143, 0.4285714, 0],
+                    [0.2857143, -0.4285714, 0.8571429, 0],
+                    [0.4285714, 0.8571429, 0.2857143, 0],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ),
+        True,
+    ],
+    [
+        torch.tensor(
+            [
+                [
+                    [-1.8571429, 0.2857143, 0.4285714, 0],
+                    [0.2857143, -0.4285714, 0.8571429, 0],
+                    [0.4285714, 0.8571429, 0.2857143, 0],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ),
+        False,
+    ],
+    [
+        torch.tensor(
+            [
+                [
+                    [-0.8571429, 0.2857143, 0.4285714, 1],
+                    [0.2857143, -0.4285714, 0.8571429, 2],
+                    [0.4285714, 0.8571429, 0.2857143, 3],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ),
+        True,
+    ],
+    [
+        torch.tensor(
+            [
+                [
+                    [-0.8571429, 0.2857143, 0.4285714, 0],
+                    [0.2857143, -0.4285714, 0.8571429, 0],
+                    [0.4285714, 0.8571429, 0.2857143, 0],
+                    [0, 0, 1, 1],
+                ]
+            ]
+        ),
+        False,
+    ],
+    [
+        torch.tensor(
+            [
+                [
+                    [-0.8571429, 0.2857143, 0.4285714, 0],
+                    [0.2857143, -0.4285714, 0.8571429, 0],
+                    [0.4285714, 0.8571429, 0.2857143, 0],
+                    [0, 0, 0, 0],
+                ]
+            ]
+        ),
+        False,
+    ],
+    [
+        torch.tensor(
+            [
+                [
+                    [1.0, 1.0, 2.0, 0],
+                    [0.0, 2.0, 0.0, 0],
+                    [2.0, 0.0, 1.0, 0],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ),
+        False,
+    ],
+    [
+        torch.tensor(
+            [
+                [
+                    [1.0, 1.0, 0.0, 0],
+                    [0.0, 1.0, 0.0, 0],
+                    [0.0, 0.0, 1.0, 0],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ),
+        False,
+    ],
+]
+
+
+euclidean_inversion = [
+    [
+        torch.tensor(
+            [
+                [
+                    [-0.8245614, 0.0701754, 0.5614035, 0],
+                    [0.4912281, -0.4035088, 0.7719298, 0],
+                    [0.2807018, 0.9122807, 0.2982456, 0],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ),
+        torch.tensor(
+            [
+                [
+                    [-0.8245614, 0.4912281, 0.2807018, 0],
+                    [0.0701754, -0.4035088, 0.9122807, 0],
+                    [0.5614035, 0.7719298, 0.2982456, 0],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ),
+    ],
+    [
+        torch.tensor(
+            [
+                [
+                    [-0.8245614, 0.0701754, 0.5614035, 1],
+                    [0.4912281, -0.4035088, 0.7719298, 2],
+                    [0.2807018, 0.9122807, 0.2982456, 3],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ),
+        torch.tensor(
+            [
+                [
+                    [-0.8245614, 0.4912281, 0.2807018, -1],
+                    [0.0701754, -0.4035088, 0.9122807, -2],
+                    [0.5614035, 0.7719298, 0.2982456, -3],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ),
+    ],
+    [
+        torch.tensor(
+            [
+                [
+                    [-0.8245614, 0.0701754, 0.5614035, 1],
+                    [0.4912281, -0.4035088, 0.7719298, 2],
+                    [0.2807018, 0.9122807, 0.2982456, 3],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ).cuda(),
+        torch.tensor(
+            [
+                [
+                    [-0.8245614, 0.4912281, 0.2807018, -1],
+                    [0.0701754, -0.4035088, 0.9122807, -2],
+                    [0.5614035, 0.7719298, 0.2982456, -3],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ).cuda(),
+    ],
+]
+
+euclidean_construct = [
+    [
+        torch.tensor([1, 2, 3, 4.0]),
+        torch.tensor([5, 6, 7.0]),
+        torch.tensor(
+            [
+                [0.1333333, -0.6666667, 0.7333333, 5],
+                [0.9333333, 0.3333333, 0.1333333, 6],
+                [-0.3333333, 0.6666667, 0.6666667, 7],
+                [0, 0, 0, 1],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([1, 2, 3, 4.0]),
+        None,
+        torch.tensor(
+            [
+                [0.1333333, -0.6666667, 0.7333333, 0],
+                [0.9333333, 0.3333333, 0.1333333, 0],
+                [-0.3333333, 0.6666667, 0.6666667, 0],
+                [0, 0, 0, 1],
+            ]
+        ),
+    ],
+    [
+        None,
+        torch.tensor([5, 6, 7.0]),
+        torch.tensor(
+            [
+                [1.0, 0, 0, 5],
+                [0, 1, 0, 6],
+                [0, 0, 1, 7],
+                [0, 0, 0, 1],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([1, 2, 3, 4.0]).cuda(),
+        torch.tensor([5, 6, 7.0]).cuda(),
+        torch.tensor(
+            [
+                [0.1333333, -0.6666667, 0.7333333, 5],
+                [0.9333333, 0.3333333, 0.1333333, 6],
+                [-0.3333333, 0.6666667, 0.6666667, 7],
+                [0, 0, 0, 1],
+            ]
+        ).cuda(),
+    ],
+]
+
+
+class TestEuclidean:
+    @pytest.mark.parametrize("euclidean,expected", euclidean_is_valid)
+    def test_is_euclidean_valid(self, euclidean: Tensor, expected: Tensor):
+        is_valid = is_euclidean_valid(euclidean)
+        assert is_valid == expected
+
+    @pytest.mark.parametrize("euclidean,expected", euclidean_inversion)
+    def test_euclidean_inverse(self, euclidean: Tensor, expected: Tensor):
+        inverted = euclidean_inverse(euclidean)
+        assert inverted.device == euclidean.device
+        assert torch.allclose(inverted, expected)
+
+        # reinverted = euclidean_inverse(inverted)
+        # assert reinverted.device == inverted.device
+        # assert torch.allclose(reinverted, euclidean)
+
+    @pytest.mark.parametrize("rotation,translation,expected", euclidean_construct)
+    def test_euclidean_inverse(self, rotation: Optional[Tensor], translation: Optional[Tensor], expected: Tensor):
+        euclidean = euclidean_from_rotation_translation(rotation, translation)
+        if rotation is not None:
+            assert euclidean.device == rotation.device
+        assert euclidean.device == expected.device
+        assert torch.allclose(euclidean, expected)

--- a/tests/python/kaolin/math/quat/test_matrix44.py
+++ b/tests/python/kaolin/math/quat/test_matrix44.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from torch import Tensor
+
+torch.backends.cuda.matmul.allow_tf32 = False
+torch.backends.cudnn.allow_tf32 = False
+torch.set_printoptions(precision=8)
+
+from kaolin.math.quat.matrix44 import scale_to_mat44, translation_to_mat44
+
+trans_to_mat44 = [
+    [
+        torch.tensor([1.0, 2.0, 3.0, 0.0]),
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0, 1.0],
+                [0.0, 1.0, 0.0, 2.0],
+                [0.0, 0.0, 1.0, 3.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([-1.0, 0.0, 0.0, 0.0]),
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0, -1.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([-1.0, 0.0, 0.0]),
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0, -1.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([-1.0, 0.0, 0.0, 5.0]),
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0, -1.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor(
+            [
+                [1.0, 2.0, 3.0, 0.0],
+                [4.0, 5.0, 6.0, 0.0],
+            ]
+        ),
+        torch.tensor(
+            [
+                [
+                    [1.0, 0.0, 0.0, 1.0],
+                    [0.0, 1.0, 0.0, 2.0],
+                    [0.0, 0.0, 1.0, 3.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ],
+                [
+                    [1.0, 0.0, 0.0, 4.0],
+                    [0.0, 1.0, 0.0, 5.0],
+                    [0.0, 0.0, 1.0, 6.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ],
+            ]
+        ),
+    ],
+]
+
+scales_to_mat44 = [
+    [
+        torch.tensor([1.0, 1.0, 1.0, 0.0]),
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([1.0, 2.0, 3.0, 0.0]),
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 2.0, 0.0, 0.0],
+                [0.0, 0.0, 3.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([1.0, 2.0, 3.0]),
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 2.0, 0.0, 0.0],
+                [0.0, 0.0, 3.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([1.0, 2.0, 3.0, 5.0]),
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 2.0, 0.0, 0.0],
+                [0.0, 0.0, 3.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor(
+            [
+                [1.0, 2.0, 3.0, 5.0],
+                [4.0, 5.0, 6.0, 10.0],
+            ]
+        ),
+        torch.tensor(
+            [
+                [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 2.0, 0.0, 0.0],
+                    [0.0, 0.0, 3.0, 0.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ],
+                [
+                    [4.0, 0.0, 0.0, 0.0],
+                    [0.0, 5.0, 0.0, 0.0],
+                    [0.0, 0.0, 6.0, 0.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ],
+            ]
+        ),
+    ],
+]
+
+
+class TestMatrix44:
+    @pytest.mark.parametrize("translation,expected", trans_to_mat44)
+    def test_translation_to_mat44(self, translation: Tensor, expected: Tensor):
+        result = translation_to_mat44(translation)
+        assert result.device == translation.device
+        assert torch.allclose(result, expected)
+
+    @pytest.mark.parametrize("scales,expected", scales_to_mat44)
+    def test_scale_to_mat44(self, scales: Tensor, expected: Tensor):
+        result = scale_to_mat44(scales)
+        assert result.device == scales.device
+        assert torch.allclose(result, expected)

--- a/tests/python/kaolin/math/quat/test_quaternion.py
+++ b/tests/python/kaolin/math/quat/test_quaternion.py
@@ -1,0 +1,528 @@
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import pytest
+import torch
+from torch import Tensor
+
+torch.backends.cuda.matmul.allow_tf32 = False
+torch.backends.cudnn.allow_tf32 = False
+torch.set_printoptions(precision=8)
+
+from kaolin.math.quat.angle_axis import angle_axis_from_quat
+from kaolin.math.quat.matrix44 import rot44_from_quat
+from kaolin.math.quat.quaternion import (
+    quat_conjugate,
+    quat_from_angle_axis,
+    quat_from_rot33,
+    quat_identity,
+    quat_mul,
+    quat_unit_positive,
+    quat_rotate,
+    quat_unit,
+)
+from kaolin.math.quat.rotation33 import rot33_from_quat
+
+shape_to_identity = [
+    [
+        [3],
+        None,
+        torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ).cuda(),
+    ],
+    [
+        [5],
+        "cpu",
+        torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+]
+
+# via: https://www.andre-gaschler.com/rotationconverter/
+q_to_unit = [
+    [torch.tensor([0.6, 0.4, 0.2, 0]), torch.tensor([0.8017837, 0.5345225, 0.2672612, 0])],
+    [torch.tensor([0.6, 0.4, 0.2, 1]), torch.tensor([0.4803845, 0.3202563, 0.1601282, 0.8006408])],
+    [torch.tensor([0.6, 0.4, 0.2, -1]), torch.tensor([0.4803845, 0.3202563, 0.1601282, -0.8006408])],
+    [torch.tensor([-0.6, 0.4, 0.2, -1]), torch.tensor([-0.4803845, 0.3202563, 0.1601282, -0.8006408])],
+    [torch.tensor([-0.6, 0.4, 0.2, -1]).cuda(), torch.tensor([-0.4803845, 0.3202563, 0.1601282, -0.8006408]).cuda()],
+    # batched
+    [
+        torch.tensor(
+            [
+                [0.6, 0.4, 0.2, -1],
+                [-0.6, 0.4, 0.2, -1],
+            ]
+        ),
+        torch.tensor(
+            [
+                [0.4803845, 0.3202563, 0.1601282, -0.8006408],
+                [-0.4803845, 0.3202563, 0.1601282, -0.8006408],
+            ]
+        ),
+    ],
+]
+
+q_to_norm = [
+    [torch.tensor([0.6, 0.4, 0.2, 0]), torch.tensor([0.8017837, 0.5345225, 0.2672612, 0])],
+    [torch.tensor([0.6, 0.4, 0.2, 1]), torch.tensor([0.4803845, 0.3202563, 0.1601282, 0.8006408])],
+    [torch.tensor([0.6, 0.4, 0.2, -1]), torch.tensor([-0.4803845, -0.3202563, -0.1601282, 0.8006408])],
+    [torch.tensor([-0.6, 0.4, 0.2, -1]), torch.tensor([0.4803845, -0.3202563, -0.1601282, 0.8006408])],
+    [torch.tensor([0.6, 0.4, 0.2, -1]).cuda(), torch.tensor([-0.4803845, -0.3202563, -0.1601282, 0.8006408]).cuda()],
+    # batched
+    [
+        torch.tensor(
+            [
+                [0.6, 0.4, 0.2, 1],
+                [0.6, 0.4, 0.2, -1],
+            ]
+        ),
+        torch.tensor(
+            [
+                [0.4803845, 0.3202563, 0.1601282, 0.8006408],
+                [-0.4803845, -0.3202563, -0.1601282, 0.8006408],
+            ]
+        ),
+    ],
+]
+
+q_to_aaxis = [
+    [
+        torch.tensor([0.8017837, 0.5345225, 0.2672612, 0]),
+        [torch.tensor(3.1415927), torch.tensor([0.8017837, 0.5345225, 0.2672612])],
+    ],
+    [
+        torch.tensor([0.4803845, 0.3202563, 0.1601282, 0.8006408]),
+        [torch.tensor(1.2848648), torch.tensor([0.8017837, 0.5345225, 0.2672612])],
+    ],
+    [
+        torch.tensor([0.4509876, 0.3006584, 0.375823, 0.751646]).cuda(),
+        [torch.tensor(1.4404843).cuda(), torch.tensor([0.6837635, 0.4558423, 0.5698029]).cuda()],
+    ],
+    # batched
+    [
+        torch.tensor(
+            [
+                [0.4509876, 0.3006584, 0.375823, 0.751646],
+                [0.4803845, 0.3202563, 0.1601282, 0.8006408],
+            ]
+        ),
+        [
+            torch.tensor(
+                [
+                    [1.4404843],
+                    [1.2848648],
+                ]
+            ),
+            torch.tensor(
+                [
+                    [0.6837635, 0.4558423, 0.5698029],
+                    [0.8017837, 0.5345225, 0.2672612],
+                ]
+            ),
+        ],
+    ],
+    [
+        torch.tensor([-0.5465269, -0.3643512, -0.1821756, 0.7316889]).cuda(),
+        [torch.tensor(1.5).cuda(), torch.tensor([-0.8017837, -0.5345225, -0.2672612]).cuda()],
+    ],
+]
+
+q_mul = [
+    [torch.tensor([1, 1, 1, 1]), torch.tensor([2, 3, 4, 1]), torch.tensor([4, 2, 6, -8])],
+    [torch.tensor([1, 1, 1, 1]), torch.tensor([2, 3, 4, -1]), torch.tensor([2, 0, 4, -10])],
+    [torch.tensor([1, 1, 1, 1]), torch.tensor([-2, 3, 4, 1]), torch.tensor([0, -2, 10, -4])],
+    [torch.tensor([1, 1, 1, 1]), torch.tensor([2, -3, 4, 1]), torch.tensor([10, -4, 0, -2])],
+    [torch.tensor([1, 1, 1, 1]), torch.tensor([2, 3, -4, 1]), torch.tensor([-4, 10, -2, 0])],
+    [torch.tensor([1, 1, 1, -1]), torch.tensor([2, 3, 4, 1]), torch.tensor([0, -4, -2, -10])],
+    # batched
+    [
+        torch.tensor(
+            [
+                [1, 1, 1, 1],
+                [1, 1, 1, -1],
+            ]
+        ),
+        torch.tensor(
+            [
+                [2, 3, -4, 1],
+                [2, 3, 4, 1],
+            ]
+        ),
+        torch.tensor(
+            [
+                [-4, 10, -2, 0],
+                [0, -4, -2, -10],
+            ]
+        ),
+    ],
+    [torch.tensor([1, 1, 1, -1]).cuda(), torch.tensor([2, 3, 4, 1]).cuda(), torch.tensor([0, -4, -2, -10]).cuda()],
+]
+
+q_conj = [
+    [torch.tensor([2, 3, 4, 1]), torch.tensor([-2, -3, -4, 1])],
+    [torch.tensor([2, 3, 4, -1]), torch.tensor([-2, -3, -4, -1])],
+    # batched
+    [
+        torch.tensor(
+            [
+                [2, 3, 4, 1],
+                [2, 3, 4, -1],
+            ]
+        ),
+        torch.tensor(
+            [
+                [-2, -3, -4, 1],
+                [-2, -3, -4, -1],
+            ]
+        ),
+    ],
+    [torch.tensor([2, 3, 4, -1]).cuda(), torch.tensor([-2, -3, -4, -1]).cuda()],
+]
+
+
+# for axis + angle -> quaternion: https://www.andre-gaschler.com/rotationconverter/
+# for rotation output: https://www.vcalc.com/wiki/vCalc/V3+-+Vector+Rotation
+q_rotate = [
+    [
+        # batched
+        # axis: 1,1,1 & 3,2,1
+        # angle: 1 (radian)
+        torch.tensor(
+            [
+                [0.2767965, 0.2767965, 0.2767965, 0.8775826],
+                [0.3843956, 0.2562637, 0.1281319, 0.8775826],
+            ]
+        ),
+        torch.tensor(
+            [
+                [1, 2, 3],
+                [1, 2, 3],
+            ]
+        ),
+        torch.tensor(
+            [
+                [1.945521194, 1.028353001, 3.026125805],
+                [2.424939115, -0.06182504, 2.848832735],
+            ]
+        ),
+    ],
+    [
+        # axis: 3,2,1
+        # angle: 1 (radian)
+        torch.tensor([[0.3843956, 0.2562637, 0.1281319, 0.8775826]]),
+        torch.tensor([[1, 2, 3]]),
+        torch.tensor([[2.424939115, -0.06182504, 2.848832735]]),
+    ],
+    [
+        # axis: 3,2,1
+        # angle: 1.5 (radian)
+        torch.tensor([[0.5465269, 0.3643512, 0.1821756, 0.7316889]]),
+        torch.tensor([[1, 2, 3]]),
+        torch.tensor([[3.128381622, -0.663741305, 1.942337742]]),
+    ],
+    [
+        # axis: 3,2,1
+        # angle: -1.5 (radian)
+        torch.tensor([[-0.5465269, -0.3643512, -0.1821756, 0.7316889]]),
+        torch.tensor([[1, 2, 3]]),
+        torch.tensor([[0.995647631, 3.601726678, -0.190396249]]),
+    ],
+    [
+        # axis: 3,2,1
+        # angle: -1.5 (radian)
+        torch.tensor([[-0.5465269, -0.3643512, -0.1821756, 0.7316889]]).cuda(),
+        torch.tensor([[1, 2, 3]]).cuda(),
+        torch.tensor([[0.995647631, 3.601726678, -0.190396249]]).cuda(),
+    ],
+]
+
+q_to_rot33 = [
+    [torch.tensor([0.0, 0.0, 0.0, 1.0]), torch.eye(3, dtype=torch.float)],
+    [
+        torch.tensor([1.0, 0.0, 0.0, 0.0]),
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, -1.0, 0.0],
+                [0.0, 0.0, -1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([0.0, 1.0, 0.0, 0.0]),
+        torch.tensor(
+            [
+                [-1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, -1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([0.0, 0.0, 1.0, 0.0]),
+        torch.tensor(
+            [
+                [-1.0, 0.0, 0.0],
+                [0.0, -1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([0.57735, 0.57735, 0.57735, 0.0]),
+        torch.tensor(
+            [
+                [-0.333333, 0.666667, 0.666667],
+                [0.666667, -0.333333, 0.666667],
+                [0.666667, 0.666667, -0.333333],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([0.8017837, 0.5345225, 0.2672612, 0]),
+        torch.tensor(
+            [[0.2857143, 0.8571429, 0.4285714], [0.8571429, -0.4285714, 0.2857143], [0.4285714, 0.2857143, -0.8571429]]
+        ),
+    ],
+    [
+        torch.tensor([0.4803845, 0.3202563, 0.1601282, 0.8006408]),
+        torch.tensor(
+            [[0.7435898, 0.0512821, 0.6666667], [0.5641026, 0.4871795, -0.6666667], [-0.3589744, 0.8717949, 0.3333333]]
+        ),
+    ],
+    # batched
+    [
+        torch.tensor(
+            [
+                [0.4803845, 0.3202563, 0.1601282, 0.8006408],
+                [0.8017837, 0.5345225, 0.2672612, 0],
+            ]
+        ),
+        torch.tensor(
+            [
+                [
+                    [0.7435898, 0.0512821, 0.6666667],
+                    [0.5641026, 0.4871795, -0.6666667],
+                    [-0.3589744, 0.8717949, 0.3333333],
+                ],
+                [
+                    [0.2857143, 0.8571429, 0.4285714],
+                    [0.8571429, -0.4285714, 0.2857143],
+                    [0.4285714, 0.2857143, -0.8571429],
+                ],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([0.4803845, 0.3202563, 0.1601282, 0.8006408]).cuda(),
+        torch.tensor(
+            [[0.7435898, 0.0512821, 0.6666667], [0.5641026, 0.4871795, -0.6666667], [-0.3589744, 0.8717949, 0.3333333]]
+        ).cuda(),
+    ],
+]
+
+q_to_mat44 = [
+    [torch.tensor([0.0, 0.0, 0.0, 1.0]), torch.eye(4, dtype=torch.float)],
+    [
+        torch.tensor([1.0, 0.0, 0.0, 0.0]),
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, -1.0, 0.0, 0.0],
+                [0.0, 0.0, -1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([0.0, 1.0, 0.0, 0.0]),
+        torch.tensor(
+            [
+                [-1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, -1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([0.0, 0.0, 1.0, 0.0]),
+        torch.tensor(
+            [
+                [-1.0, 0.0, 0.0, 0.0],
+                [0.0, -1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([0.57735, 0.57735, 0.57735, 0.0]),
+        torch.tensor(
+            [
+                [-0.333333, 0.666667, 0.666667, 0.0],
+                [0.666667, -0.333333, 0.666667, 0.0],
+                [0.666667, 0.666667, -0.333333, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([0.8017837, 0.5345225, 0.2672612, 0]),
+        torch.tensor(
+            [
+                [0.2857143, 0.8571429, 0.4285714, 0],
+                [0.8571429, -0.4285714, 0.2857143, 0],
+                [0.4285714, 0.2857143, -0.8571429, 0],
+                [0, 0, 0, 1],
+            ]
+        ),
+    ],
+    # batched
+    [
+        torch.tensor(
+            [
+                [0.8017837, 0.5345225, 0.2672612, 0],
+                [0.4803845, 0.3202563, 0.1601282, 0.8006408],
+            ]
+        ),
+        torch.tensor(
+            [
+                [
+                    [0.2857143, 0.8571429, 0.4285714, 0],
+                    [0.8571429, -0.4285714, 0.2857143, 0],
+                    [0.4285714, 0.2857143, -0.8571429, 0],
+                    [0, 0, 0, 1],
+                ],
+                [
+                    [0.7435898, 0.0512821, 0.6666667, 0],
+                    [0.5641026, 0.4871795, -0.6666667, 0],
+                    [-0.3589744, 0.8717949, 0.3333333, 0],
+                    [0, 0, 0, 1],
+                ],
+            ]
+        ),
+    ],
+    [
+        torch.tensor([0.4803845, 0.3202563, 0.1601282, 0.8006408]),
+        torch.tensor(
+            [
+                [0.7435898, 0.0512821, 0.6666667, 0],
+                [0.5641026, 0.4871795, -0.6666667, 0],
+                [-0.3589744, 0.8717949, 0.3333333, 0],
+                [0, 0, 0, 1],
+            ]
+        ),
+    ],
+    # CUDA
+    [
+        torch.tensor([0.4803845, 0.3202563, 0.1601282, 0.8006408]).cuda(),
+        torch.tensor(
+            [
+                [0.7435898, 0.0512821, 0.6666667, 0],
+                [0.5641026, 0.4871795, -0.6666667, 0],
+                [-0.3589744, 0.8717949, 0.3333333, 0],
+                [0, 0, 0, 1],
+            ]
+        ).cuda(),
+    ],
+]
+
+
+class TestQuaternion:
+    @pytest.mark.parametrize("shape,device,expected", shape_to_identity)
+    def test_quat_identity(self, shape: Tensor, device: Optional[torch.device], expected: Tensor):
+        if device:
+            identity = quat_identity(shape, device=device)
+            assert str(identity.device) == device
+        else:
+            identity = quat_identity(shape)
+        assert identity.device == expected.device
+        assert torch.allclose(identity, expected)
+
+    @pytest.mark.parametrize("q,expected", q_to_norm)
+    def test_quat_unit_positive(self, q: Tensor, expected: Tensor):
+        qnorm = quat_unit_positive(q)
+        assert qnorm.device == q.device
+        assert torch.allclose(qnorm, expected)
+
+    @pytest.mark.parametrize("q,expected", q_to_rot33)
+    def test_to_rot33(self, q: Tensor, expected: Tensor):
+        mat = rot33_from_quat(q)
+        assert mat.device == q.device
+        assert torch.allclose(mat, expected)
+
+        q2 = quat_from_rot33(mat)
+        assert torch.allclose(q, q2)
+
+    @pytest.mark.parametrize("q,expected", q_to_mat44)
+    def test_to_rot44(self, q: Tensor, expected: Tensor):
+        mat = rot44_from_quat(q)
+        assert mat.device == q.device
+        assert torch.allclose(mat, expected)
+
+    @pytest.mark.parametrize("q,expected", q_to_aaxis)
+    def test_quat_to_angle_axis(self, q: Tensor, expected: Tensor):
+        angle, axis = angle_axis_from_quat(q)
+        assert angle.device == q.device
+        assert axis.device == q.device
+        assert torch.allclose(angle, expected[0])
+        assert torch.allclose(axis, expected[1])
+
+        # TODO: need to check negative angles & expected behavior
+        qnorm = quat_unit_positive(q)
+        q2 = quat_from_angle_axis(angle, axis)
+        assert q2.device == angle.device
+        assert torch.allclose(q2, qnorm, atol=1e-6)
+
+    @pytest.mark.parametrize("q,expected", q_to_unit)
+    def test_unit(self, q: Tensor, expected: Tensor):
+        qnorm = quat_unit(q)
+        assert qnorm.device == q.device
+        assert torch.allclose(qnorm, expected)
+
+    @pytest.mark.parametrize("q,expected", q_conj)
+    def test_conj(self, q: Tensor, expected: Tensor):
+        q2 = quat_conjugate(q)
+        assert q.device == q2.device
+        assert torch.allclose(q2, expected)
+
+    @pytest.mark.parametrize("q1,q2,expected", q_mul)
+    def test_mul(self, q1: Tensor, q2: Tensor, expected: Tensor):
+        q3 = quat_mul(q1, q2)
+        assert q3.device == q2.device
+        assert q3.device == q1.device
+        assert torch.allclose(q3, expected)
+
+    @pytest.mark.parametrize("q,point,expected", q_rotate)
+    def test_rotate(self, q: Tensor, point: Tensor, expected: Tensor):
+        rot = quat_rotate(q, point)
+        assert rot.device == q.device
+        assert q.device == point.device
+        assert torch.allclose(rot, expected, atol=1e-5)

--- a/tests/python/kaolin/math/quat/test_rotation33.py
+++ b/tests/python/kaolin/math/quat/test_rotation33.py
@@ -1,0 +1,381 @@
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from .test_quaternion import q_to_rot33
+from torch import Tensor
+
+from kaolin.math.quat.angle_axis import angle_axis_from_rot33
+from kaolin.math.quat.quaternion import quat_from_rot33
+
+torch.backends.cuda.matmul.allow_tf32 = False
+torch.backends.cudnn.allow_tf32 = False
+torch.set_printoptions(precision=8)
+
+from kaolin.math.quat.rotation33 import (
+    is_rot33_valid,
+    rot33_from_angle_axis,
+    rot33_from_quat,
+    rot33_rotate,
+)
+
+rot33_is_valid = [
+    [
+        torch.tensor(
+            [
+                [
+                    [-0.8571429, 0.2857143, 0.4285714],
+                    [0.2857143, -0.4285714, 0.8571429],
+                    [0.4285714, 0.8571429, 0.2857143],
+                ]
+            ]
+        ),
+        True,
+    ],
+    [
+        torch.tensor(
+            [
+                [
+                    [-0.7333333, -0.1333333, 0.6666667],
+                    [0.6666667, -0.3333333, 0.6666667],
+                    [0.1333333, 0.9333333, 0.3333333],
+                ]
+            ]
+        ),
+        True,
+    ],
+    # batched
+    [
+        torch.tensor(
+            [
+                [
+                    [-0.8571429, 0.2857143, 0.4285714],
+                    [0.2857143, -0.4285714, 0.8571429],
+                    [0.4285714, 0.8571429, 0.2857143],
+                ],
+                [
+                    [-0.7333333, -0.1333333, 0.6666667],
+                    [0.6666667, -0.3333333, 0.6666667],
+                    [0.1333333, 0.9333333, 0.3333333],
+                ],
+            ]
+        ),
+        True,
+    ],
+    # batched
+    [
+        torch.tensor(
+            [
+                [
+                    [1.0, 1.0, 2.0],
+                    [0.0, 2.0, 0.0],
+                    [2.0, 0.0, 1.0],
+                ],
+                [
+                    [-0.7333333, -0.1333333, 0.6666667],
+                    [0.6666667, -0.3333333, 0.6666667],
+                    [0.1333333, 0.9333333, 0.3333333],
+                ],
+            ]
+        ),
+        False,
+    ],
+    [
+        torch.tensor(
+            [
+                [
+                    [1.0, 1.0, 2.0],
+                    [0.0, 2.0, 0.0],
+                    [2.0, 0.0, 1.0],
+                ]
+            ]
+        ),
+        False,
+    ],
+    [
+        torch.tensor(
+            [
+                [
+                    [1.0, 1.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                ]
+            ]
+        ),
+        False,
+    ],
+]
+
+# 1-axis examples: https://www.gatevidyalay.com/3d-rotation-in-computer-graphics-definition-examples/
+rot33_point_rotation = [
+    # x-axis rotate 90 degrees
+    [
+        torch.tensor([1.0, 2.0, 3.0]),
+        torch.tensor(
+            [
+                [
+                    [1.0, 0.0, 0.0],
+                    [0.0, 0.0, -1.0],
+                    [0.0, 1.0, 0.0],
+                ]
+            ]
+        ),
+        torch.tensor([1.0, -3.0, 2.0]),
+    ],
+    # y-axis rotate 90 degrees
+    [
+        torch.tensor([1.0, 2.0, 3.0]),
+        torch.tensor(
+            [
+                [
+                    [0.0, 0.0, 1.0],
+                    [0.0, 1.0, 0.0],
+                    [-1.0, 0.0, 0.0],
+                ]
+            ]
+        ),
+        torch.tensor([3.0, 2.0, -1.0]),
+    ],
+    # z-axis rotate 90 degrees
+    [
+        torch.tensor([1.0, 2.0, 3.0]),
+        torch.tensor(
+            [
+                [
+                    [0.0, -1.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                ]
+            ]
+        ),
+        torch.tensor([-2.0, 1.0, 3.0]),
+    ],
+    # all-axis rotate 90 degrees
+    [
+        torch.tensor([1.0, 2.0, 3.0]),
+        torch.tensor(
+            [
+                [
+                    [0.0, 0.0, 1.0],
+                    [0.0, -1.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                ]
+            ]
+        ),
+        torch.tensor([3.0, -2.0, 1.0]),
+    ],
+    # x-axis rotate 45 degrees
+    [
+        torch.tensor([1.0, 2.0, 3.0]),
+        torch.tensor(
+            [
+                [
+                    [1, 0.0, 0.0],
+                    [0.0, 0.7071069, -0.7071069],
+                    [0.0, 0.7071069, 0.7071069],
+                ]
+            ]
+        ),
+        torch.tensor([1.0, -0.7071069, 3.5355]),
+    ],
+    # batched: all-axis rotate 90 degrees & x-axis rotate 45 degrees
+    [
+        torch.tensor(
+            [
+                [1.0, 2.0, 3.0],
+                [1.0, 2.0, 3.0],
+            ]
+        ),
+        torch.tensor(
+            [
+                [
+                    [0.0, 0.0, 1.0],
+                    [0.0, -1.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                ],
+                [
+                    [1, 0.0, 0.0],
+                    [0.0, 0.7071069, -0.7071069],
+                    [0.0, 0.7071069, 0.7071069],
+                ],
+            ]
+        ),
+        torch.tensor(
+            [
+                [3.0, -2.0, 1.0],
+                [1.0, -0.7071069, 3.5355],
+            ]
+        ),
+    ],
+    # x-axis rotate 45 degrees, y & z 90 degrees
+    [
+        torch.tensor([1.0, 2.0, 3.0]).cuda(),
+        torch.tensor(
+            [
+                [
+                    [0.0, 0.0, 1.0],
+                    [0.7071069, -0.7071069, 0.0],
+                    [0.7071069, 0.7071069, 0.0],
+                ]
+            ],
+        ).cuda(),
+        torch.tensor([3.0000, -0.7071, 2.1213]).cuda(),
+    ],
+]
+
+
+axis_angle_to_rot33 = [
+    [
+        torch.tensor(3.14),
+        torch.tensor([0.2672612, 0.5345225, 0.8017837]),
+        torch.tensor(
+            [
+                [-0.8571417, 0.2844371, 0.4294225],
+                [0.2869911, -0.4285705, 0.8567166],
+                [0.4277199, 0.8575680, 0.2857147],
+            ]
+        ),
+    ],
+    [
+        torch.tensor(-1.0),
+        torch.tensor([0.2672612, 0.5345225, 0.8017837]),
+        torch.tensor(
+            [
+                [
+                    [0.5731379, 0.7403488, -0.3512785],
+                    [-0.6090066, 0.6716445, 0.4219059],
+                    [0.5482918, -0.0278793, 0.8358222],
+                ]
+            ]
+        ),
+    ],
+    # batched
+    [
+        torch.tensor(
+            [
+                [3.14],
+                [-1.0],
+            ]
+        ),
+        torch.tensor(
+            [
+                [0.2672612, 0.5345225, 0.8017837],
+                [0.2672612, 0.5345225, 0.8017837],
+            ]
+        ),
+        torch.tensor(
+            [
+                [
+                    [-0.8571417, 0.2844371, 0.4294225],
+                    [0.2869911, -0.4285705, 0.8567166],
+                    [0.4277199, 0.8575680, 0.2857147],
+                ],
+                [
+                    [0.5731379, 0.7403488, -0.3512785],
+                    [-0.6090066, 0.6716445, 0.4219059],
+                    [0.5482918, -0.0278793, 0.8358222],
+                ],
+            ]
+        ),
+    ],
+    [
+        torch.tensor(-1.0, requires_grad=True),
+        torch.tensor([0.2672612, 0.5345225, 0.8017837], requires_grad=True),
+        torch.tensor(
+            [
+                [
+                    [0.5731379, 0.7403488, -0.3512785],
+                    [-0.6090066, 0.6716445, 0.4219059],
+                    [0.5482918, -0.0278793, 0.8358222],
+                ]
+            ],
+            requires_grad=True,
+        ),
+    ],
+    [
+        torch.tensor(-1.0, requires_grad=True).cuda(),
+        torch.tensor([0.2672612, 0.5345225, 0.8017837], requires_grad=True).cuda(),
+        torch.tensor(
+            [
+                [
+                    [0.5731379, 0.7403488, -0.3512785],
+                    [-0.6090066, 0.6716445, 0.4219059],
+                    [0.5482918, -0.0278793, 0.8358222],
+                ]
+            ],
+            requires_grad=True,
+        ).cuda(),
+    ],
+]
+
+
+class TestRotation33:
+    @pytest.mark.parametrize("rot33,expected", rot33_is_valid)
+    def test_is_rot33_valid(self, rot33: Tensor, expected: Tensor):
+        is_valid = is_rot33_valid(rot33)
+        assert is_valid == expected
+
+    @pytest.mark.parametrize("expected,rot33", q_to_rot33)
+    def test_rot33_to_quaternion(self, expected: Tensor, rot33: Tensor):
+        q = quat_from_rot33(rot33)
+        assert q.device == rot33.device
+        assert torch.allclose(q, expected)
+
+        r2 = rot33_from_quat(q)
+        assert r2.device == rot33.device
+        assert torch.allclose(r2, rot33)
+
+    @pytest.mark.parametrize("angle,axis,expected", axis_angle_to_rot33)
+    def test_angle_axis_to_rot33(self, angle: Tensor, axis: Tensor, expected: Tensor):
+        rot33 = rot33_from_angle_axis(angle, axis)
+        assert angle.device == axis.device
+        assert rot33.device == angle.device
+        assert angle.requires_grad == axis.requires_grad
+        assert rot33.requires_grad == angle.requires_grad
+        assert torch.allclose(rot33, expected, rtol=1e-3, atol=1e-5)
+
+        angle2, axis2 = angle_axis_from_rot33(rot33)
+        assert angle2.device == angle.device
+        assert angle2.device == angle.device
+        assert axis2.device == axis.device
+        assert axis2.device == axis.device
+
+        if angle.ndim > 0:
+            # TODO: vectorize. dumb fix for now
+            for idx in range(angle.shape[0]):
+                if angle[idx] > 0:
+                    assert torch.allclose(angle2[idx], angle[idx])
+                    assert torch.allclose(axis2[idx], axis[idx])
+                else:
+                    # method guarantees positive angle, so flip both signs
+                    assert torch.allclose(-angle2[idx], angle[idx])
+                    assert torch.allclose(-axis2[idx], axis[idx])
+        else:
+            if angle > 0:
+                assert torch.allclose(angle2, angle)
+                assert torch.allclose(axis2, axis)
+            else:
+                # method guarantees positive angle, so flip both signs
+                assert torch.allclose(-angle2, angle)
+                assert torch.allclose(-axis2, axis)
+
+    @pytest.mark.parametrize("point,rot33,expected", rot33_point_rotation)
+    def test_rot33_rotate(self, point: Tensor, rot33: Tensor, expected: Tensor):
+        rotated = rot33_rotate(point, rot33)
+        assert point.device == rot33.device
+        assert rotated.device == point.device
+        assert rotated.device == expected.device
+        assert torch.allclose(rotated, expected)

--- a/tests/python/kaolin/math/quat/test_transform.py
+++ b/tests/python/kaolin/math/quat/test_transform.py
@@ -1,0 +1,318 @@
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import pytest
+import torch
+from torch import Tensor
+
+torch.backends.cuda.matmul.allow_tf32 = False
+torch.backends.cudnn.allow_tf32 = False
+torch.set_printoptions(precision=8)
+
+from .test_quaternion import q_rotate
+
+from kaolin.math.quat.transform import (
+    transform_apply,
+    transform_from_euclidean,
+    transform_from_rotation_translation,
+    transform_identity,
+    transform_inverse,
+    transform_mul,
+)
+
+shape_to_identity = [
+    [
+        [3],
+        None,
+        torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+            ]
+        ).cuda(),
+    ],
+    [
+        [5],
+        "cpu",
+        torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+            ]
+        ),
+    ],
+]
+
+transform_to_inverse = [
+    [
+        torch.tensor(
+            [
+                [-0.8245614, 0.0701754, 0.5614035, 0, 0, 0, 0],
+                [0.4912281, -0.4035088, 0.7719298, 0, 0, 0, 0],
+                [0.2807018, 0.9122807, 0.2982456, 0, 0, 0, 0],
+            ]
+        ),
+        torch.tensor(
+            [
+                [0.8245614, -0.0701754, -0.5614035, 0, 0, 0, 0],
+                [-0.4912281, 0.4035088, -0.7719298, 0, 0, 0, 0],
+                [-0.2807018, -0.9122807, -0.2982456, 0, 0, 0, 0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 1],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 2],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 3],
+            ]
+        ),
+        torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0, 0, 0, -1],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, -2],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, -3],
+            ]
+        ),
+    ],
+    [
+        torch.tensor(
+            [
+                [-0.8246, 0.0702, 0.5614, 0, 0, 0, 1],
+            ]
+        ),
+        torch.tensor(
+            [
+                [0.82459998, -0.07020000, -0.56140000, 0.00000000, 0.92586088, -0.07882056, 0.36972323],
+            ]
+        ),
+    ],
+    [
+        torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 1],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 2],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 3],
+            ]
+        ).cuda(),
+        torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0, 0, 0, -1],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, -2],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, -3],
+            ]
+        ).cuda(),
+    ],
+]
+
+transform_multiply = [
+    [
+        torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 1],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 2],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 3],
+            ]
+        ),
+        torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 4],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 5],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 6],
+            ]
+        ),
+        torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 5],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 7],
+                [0.0, 0.0, 0.0, 1.0, 0, 0, 9],
+            ]
+        ),
+    ],
+    [
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0, 1.0, 0, 0, 0],
+            ]
+        ),
+        torch.tensor(
+            [
+                [3.0, 0.0, 0.0, 1.0, 0, 0, 0],
+            ]
+        ),
+        torch.tensor(
+            [
+                [-0.89442718, -0.00000000, -0.00000000, 0.44721359, 0, 0, 0],
+            ]
+        ),
+    ],
+    [
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0, 1.0, 0, 0, 1],
+            ]
+        ),
+        torch.tensor(
+            [
+                [3.0, 0.0, 0.0, 1.0, 0, 0, 1],
+            ]
+        ),
+        torch.tensor(
+            [
+                [-0.89442718, -0.00000000, -0.00000000, 0.44721359, 0, -2, 1],
+            ]
+        ),
+    ],
+    [
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0, 1.0, 0, 0, 1],
+            ]
+        ).cuda(),
+        torch.tensor(
+            [
+                [3.0, 0.0, 0.0, 1.0, 0, 0, 1],
+            ]
+        ).cuda(),
+        torch.tensor(
+            [
+                [-0.89442718, -0.00000000, -0.00000000, 0.44721359, 0, -2, 1],
+            ]
+        ).cuda(),
+    ],
+]
+
+euclidean_to_pq = [
+    [
+        torch.tensor(
+            [
+                [
+                    [-0.8571429, 0.2857143, 0.4285714, 0],
+                    [0.2857143, -0.4285714, 0.8571429, 0],
+                    [0.4285714, 0.8571429, 0.2857143, 0],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ),
+        torch.tensor([0.2672612, 0.5345225, 0.8017837, 0, 0, 0, 0]),
+    ],
+    [
+        torch.tensor(
+            [
+                [
+                    [0.1333333, -0.6666667, 0.7333333, 5],
+                    [0.9333333, 0.3333333, 0.1333333, 6],
+                    [-0.3333333, 0.6666667, 0.6666667, 7],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ),
+        torch.tensor([0.1825742, 0.3651484, 0.5477226, 0.7302967, 5, 6, 7]),
+    ],
+    # batched
+    [
+        torch.tensor(
+            [
+                [
+                    [-0.8571429, 0.2857143, 0.4285714, 0],
+                    [0.2857143, -0.4285714, 0.8571429, 0],
+                    [0.4285714, 0.8571429, 0.2857143, 0],
+                    [0, 0, 0, 1],
+                ],
+                [
+                    [0.1333333, -0.6666667, 0.7333333, 5],
+                    [0.9333333, 0.3333333, 0.1333333, 6],
+                    [-0.3333333, 0.6666667, 0.6666667, 7],
+                    [0, 0, 0, 1],
+                ],
+            ]
+        ),
+        torch.tensor(
+            [
+                [0.2672612, 0.5345225, 0.8017837, 0, 0, 0, 0],
+                [0.1825742, 0.3651484, 0.5477226, 0.7302967, 5, 6, 7],
+            ]
+        ),
+    ],
+    [
+        torch.tensor(
+            [
+                [
+                    [0.1333333, -0.6666667, 0.7333333, 5],
+                    [0.9333333, 0.3333333, 0.1333333, 6],
+                    [-0.3333333, 0.6666667, 0.6666667, 7],
+                    [0, 0, 0, 1],
+                ]
+            ]
+        ).cuda(),
+        torch.tensor([0.1825742, 0.3651484, 0.5477226, 0.7302967, 5, 6, 7]).cuda(),
+    ],
+]
+
+
+class TestTransform:
+    @pytest.mark.parametrize("shape,device,expected", shape_to_identity)
+    def test_transform_identity(self, shape: Tensor, device: Optional[torch.device], expected: Tensor):
+        if device:
+            identity = transform_identity(shape, device=device)
+            assert str(identity.device) == device
+        else:
+            identity = transform_identity(shape)
+        assert identity.device == expected.device
+        assert torch.allclose(identity, expected)
+
+    @pytest.mark.parametrize("transform,expected", transform_to_inverse)
+    def test_transform_inverse(self, transform: Tensor, expected: Tensor):
+        inverted = transform_inverse(transform)
+        assert inverted.device == transform.device
+        assert inverted.requires_grad == transform.requires_grad
+        assert torch.allclose(inverted, expected)
+
+    @pytest.mark.parametrize("t1,t2,expected", transform_multiply)
+    def test_transform_mul(self, t1: Tensor, t2: Tensor, expected: Tensor):
+        result = transform_mul(t1, t2)
+        assert t1.device == t2.device
+        assert t1.requires_grad == t2.requires_grad
+        assert result.device == t1.device
+        assert result.requires_grad == t1.requires_grad
+        assert result.device == expected.device
+        assert result.requires_grad == expected.requires_grad
+        assert torch.allclose(result, expected)
+
+    @pytest.mark.parametrize("q,point,expected", q_rotate)
+    def test_transform_apply_rotate(self, q: Tensor, point: Tensor, expected: Tensor):
+        """Transform pure rotation should be identical to quaternion rotation."""
+        transform = transform_from_rotation_translation(rotation=q)
+        result = transform_apply(transform, point)
+        assert transform.device == point.device
+        assert transform.requires_grad == point.requires_grad
+        assert result.device == transform.device
+        assert result.requires_grad == transform.requires_grad
+        assert result.device == expected.device
+        assert result.requires_grad == expected.requires_grad
+        assert torch.allclose(result, expected)
+
+    @pytest.mark.parametrize("euclidean,expected", euclidean_to_pq)
+    def test_from_euclidean(self, euclidean: Tensor, expected: Tensor):
+        transform = transform_from_euclidean(euclidean)
+        assert transform.device == euclidean.device
+        assert torch.allclose(transform, expected)


### PR DESCRIPTION
Implement quaternion conversion operations.
- Convert to: 3x3 or 4x4 Euclidean and angle-axis representations.
- Supports batched tensors.
- Includes tests for conversions among representations.
- Includes examples of some quaternion basic representations and conversions.