### PR TITLE
Fix Typos in Comments and Docstrings

### DIFF
--- a/kaolin/ops/spc/bf_recon.py
+++ b/kaolin/ops/spc/bf_recon.py
@@ -325,7 +325,7 @@ def bf_recon(input_dataset, final_level, sigma):
                 octree1, empty1, probs1, colors1, normals1 = processFrame(batch, final_level, sigma)
                 lengths = torch.tensor([len(octree1)], dtype=torch.int)
                 level, pyramid1, exsum1 = spc.scan_octrees(octree1, lengths)
-                # fuse new single frame SPC into existing cummulative SPC model
+                # fuse new single frame SPC into existing cumulative SPC model
                 octree0, empty0, probs0, colors0, normals0 = fuseBF(level,
                                                                     octree0, octree1,
                                                                     empty0, empty1,

--- a/kaolin/render/camera/intrinsics_pinhole.py
+++ b/kaolin/render/camera/intrinsics_pinhole.py
@@ -590,7 +590,7 @@ class PinholeIntrinsics(CameraIntrinsics):
 
     @CameraIntrinsics.height.setter
     def height(self, value: int) -> None:
-        """ Updates the hieght of the image plane.
+        """ Updates the height of the image plane.
         The fov will remain invariant, and the focal length may change instead.
         """
         # Keep the fov invariant and change focal length instead


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in the codebase:
- In `kaolin/ops/spc/bf_recon.py`, the word "cummulative" was corrected to "cumulative" in a comment.
- In `kaolin/render/camera/intrinsics_pinhole.py`, the word "heigh" was corrected to "height" in a docstring.

These changes improve code readability and maintain documentation accuracy. No functional code was modified.