### PR TITLE
Added as_dict, from_dict to cameras and materials 

### DIFF
--- a/kaolin/render/camera/camera.py
+++ b/kaolin/render/camera/camera.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -88,7 +88,7 @@ def _gather_constructors(*cam_modules: CameraModuleType) -> Dict[FrozenSet, Tupl
     ctors = []
     for cam_module in cam_modules:
         # Constructors are @classmethod with a 'from_' prefix
-        is_ctor = lambda x: inspect.ismethod(x) and x.__name__.startswith('from_')
+        is_ctor = lambda x: inspect.ismethod(x) and x.__name__.startswith('from_') and x.__name__ != 'from_dict'
 
         # Get all methods that satisfy the constructor predicate.
         ctors.extend(inspect.getmembers(cam_module, predicate=is_ctor))
@@ -278,6 +278,32 @@ class Camera:
         assert extrinsics.device == intrinsics.device
         self.extrinsics: CameraExtrinsics = extrinsics
         self.intrinsics: CameraIntrinsics = intrinsics
+
+    def as_dict(self):
+        r"""Returns parameters necessary to instantiate same Camera as a dictionary that is writable to
+        JSON or YAML.
+
+        Returns:
+            dict
+        """
+        if len(self) > 1:
+            raise ValueError(f'Can only export a single camera as a dictionary, this camera batch size is {len(self)}')
+
+        return {'intrinsics': self.intrinsics.as_dict(),
+                'extrinsics': self.extrinsics.as_dict()}
+
+    @classmethod
+    def from_dict(cls, in_dict):
+        r"""Constructs camera from a simple dictionary, such as that returned from as_dict.
+
+        Returns: Camera
+        """
+        intrinsics_dict = in_dict.get('intrinsics', None)
+        extrinsics_dict = in_dict.get('extrinsics', None)
+        if intrinsics_dict is None or extrinsics_dict is None:
+            raise ValueError(f'Missing "intrinsics" or "extrinsics" in param dict with keys {in_dict.keys()}')
+        return Camera(extrinsics=CameraExtrinsics.from_dict(extrinsics_dict),
+                      intrinsics=CameraIntrinsics.from_dict(intrinsics_dict))
 
     @classmethod
     def from_args(cls, **kwargs):

--- a/kaolin/render/camera/extrinsics.py
+++ b/kaolin/render/camera/extrinsics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -154,7 +154,7 @@ class CameraExtrinsics():
 
     @torch.no_grad()
     def _internal_switch_backend(self, backend_name: str):
-        """
+        r"""
         Switches the representation backend to a different implementation.
         'backend_name' must be a registered backend.
         
@@ -173,7 +173,7 @@ class CameraExtrinsics():
 
     @torch.no_grad()
     def switch_backend(self, backend_name: str):
-        """Switches the representation backend to a different implementation.
+        r"""Switches the representation backend to a different implementation.
 
         .. note::
 
@@ -266,6 +266,25 @@ class CameraExtrinsics():
             return data.to(dtype=dtype, device=device)
         else:
             return torch.tensor(data, device=device, dtype=dtype)
+
+    def as_dict(self):
+        r"""Returns parameters necessary to instantiate same `CameraExtrinsics` using `from_dict`; this dictionary
+        is writable to JSON or YAML.
+
+        Returns:
+            dict
+        """
+        return {'view_matrix': self.view_matrix().squeeze(0).detach().cpu().numpy().tolist()}
+
+    @classmethod
+    def from_dict(cls, in_dict):
+        r"""Constructs class from a simple dictionary, such as that returned from as_dict; uses default back end.
+
+        Returns:
+            CameraExtrinsics
+        """
+        view_matrix = torch.from_numpy(np.array(in_dict['view_matrix']))
+        return cls.from_view_matrix(view_matrix)
 
     @classmethod
     def from_camera_pose(cls,

--- a/kaolin/render/camera/extrinsics_backends.py
+++ b/kaolin/render/camera/extrinsics_backends.py
@@ -222,7 +222,7 @@ class _Matrix6DofRotationRep(ExtrinsicsRep):
         b1 = torch.nn.functional.normalize(a1, dim=1)
         b1_dot_a2 = torch.bmm(b1.view(-1, 1, 3), a2.view(-1, 3, 1)).view(batch_size, 1)    # Batched dot product
         b2 = torch.nn.functional.normalize(a2 - b1_dot_a2 * b1, dim=1)
-        b3 = torch.cross(b1, b2)
+        b3 = torch.linalg.cross(b1, b2)
 
         rotation = torch.stack([b1, b2, b3], dim=1)  # Stack row-wise
         extrinsics_mat = torch.cat([rotation, translation.unsqueeze(-1)], dim=2)  # Stack column-wise

--- a/kaolin/render/camera/intrinsics.py
+++ b/kaolin/render/camera/intrinsics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,6 +83,8 @@ IntrinsicsParamsDefEnum = IntEnum
 
 
 class CameraIntrinsics(ABC):
+    __registered_subclasses = {}
+
     r"""Holds the intrinsics parameters of a camera: how it should project from camera space to
     normalized screen / clip space.
 
@@ -127,6 +129,47 @@ class CameraIntrinsics(ABC):
             ndc_min=-1.0,              # Min value of NDC space
             ndc_max=1.0                # Max value of NDC space
         )
+
+    def __init_subclass__(cls, **kwargs):
+        """Called automatically when Base is subclassed"""
+        super().__init_subclass__(**kwargs)
+
+        name = cls.registered_name()
+        cls.__registered_subclasses[name] = cls
+
+    @abstractmethod
+    def _as_dict(self):
+        raise NotImplementedError
+
+    @classmethod
+    def registered_name(cls):
+        return cls.__name__
+
+    def as_dict(self):
+        r"""Returns parameters necessary to instantiate same `CameraInitrinsics` as a dictionary that is writable to
+            JSON or YAML.
+
+            Returns:
+                dict
+        """
+        res = self._as_dict()
+        res['classname'] = self.__class__.registered_name()
+        return res
+
+    @staticmethod
+    def from_dict(in_dict):
+        r"""Constructs intrinsics from a simple dictionary, such as that returned from `as_dict`; uses registered
+        subclasses to figure out which subclass to instantiate based on its `registered_name`.
+
+        Returns: CameraIntrinsics subclass instance.
+        """
+        name = in_dict.get('classname', None)
+        if name is None or name not in CameraIntrinsics.__registered_subclasses:
+            raise ValueError(f'Input dict "classname" value {name} not found in registered '
+                             f'CameraIntrinsics values: {CameraIntrinsics.__registered_subclasses.keys()}')
+        cls = CameraIntrinsics.__registered_subclasses[name]
+        meta = {k: v for k, v in in_dict.items() if k != 'classname'}
+        return cls.from_dict(meta)
 
     def aspect_ratio(self) -> float:
         """Returns the aspect ratio of the cameras held by this object."""

--- a/kaolin/render/camera/intrinsics_ortho.py
+++ b/kaolin/render/camera/intrinsics_ortho.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,6 +53,29 @@ class OrthographicIntrinsics(CameraIntrinsics):
     def __init__(self, width: int, height: int, params: torch.Tensor,
                  near: float = DEFAULT_NEAR, far: float = DEFAULT_FAR):
         super().__init__(width, height, params, near, far)
+
+    @classmethod
+    def registered_name(cls):
+        return 'orthographic'
+
+    def _as_dict(self):
+        return {
+            'width': self.width,
+            'height': self.height,
+            'fov_distance': self.fov_distance.item(),
+            'near': self.near,
+            'far': self.far,
+        }
+
+
+    @classmethod
+    def from_dict(cls, in_dict):
+        r"""Constructs orthographic intrinsics from a simple dictionary, such as that returned from `as_dict`.
+
+        Returns: OrthographicIntrinsics instance.
+        """
+        meta = {k: v for k, v in in_dict.items() if k != 'classname'}
+        return cls.from_frustum(**meta)
 
     @classmethod
     def param_types(cls) -> Type[IntrinsicsParamsDefEnum]:

--- a/kaolin/render/camera/intrinsics_pinhole.py
+++ b/kaolin/render/camera/intrinsics_pinhole.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -233,6 +233,31 @@ class PinholeIntrinsics(CameraIntrinsics):
         focal = aspectScale / tanHalfAngle
         params = cls._allocate_params(x0, y0, focal, focal, num_cameras=num_cameras, device=device, dtype=dtype)
         return PinholeIntrinsics(width, height, params, near, far)
+
+    @classmethod
+    def registered_name(cls):
+        return 'pinhole'
+
+    def _as_dict(self):
+        return {
+            'width': self.width,
+            'height': self.height,
+            'focal_x': self.focal_x.item(),
+            'focal_y': self.focal_y.item(),
+            'x0': self.x0.item(),
+            'y0': self.y0.item(),
+            'near': self.near,
+            'far': self.far
+        }
+
+    @classmethod
+    def from_dict(cls, in_dict):
+        r"""Constructs pinhole intrinsics from a simple dictionary, such as that returned from `as_dict`.
+
+        Returns: PinholeIntrinsics instance.
+        """
+        meta = {k: v for k, v in in_dict.items() if k != 'classname'}
+        return cls.from_focal(**meta)
 
     def perspective_matrix(self) -> torch.Tensor:
         r"""Constructs a matrix which performs perspective projection from camera space to homogeneous clip space.

--- a/kaolin/render/materials.py
+++ b/kaolin/render/materials.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
 import copy
 import random
 import torch
+from abc import ABC, abstractmethod
 
 import kaolin.utils.testing
 
@@ -28,7 +29,7 @@ def _to_1d_tensor(data):
         return torch.tensor(data).reshape(-1).float()
 
 
-class Material:
+class Material(ABC):
     """Abstract material definition class.
     Defines material inputs and methods to export material properties.
     """
@@ -36,6 +37,19 @@ class Material:
         self.material_name = str(name)
         self.shader_name = str(shader_name)
 
+    @abstractmethod
+    def as_dict(self):
+        raise NotImplementedError
+
+    @staticmethod
+    def from_dict(in_dict):
+        name = in_dict.get('classname', None)
+        if name == 'pbr':
+            meta = {k: v for k, v in in_dict.items() if k != 'classname'}
+            return PBRMaterial.from_dict(meta)
+        else:
+            raise ValueError(f'Input dict "classname" value {name} not supported, expected "pbr"')
+        
 
 class PBRMaterial(Material):
     """Defines a PBR material; allows storing rendering material properties imported from USD, gltf, obj,
@@ -196,6 +210,10 @@ class PBRMaterial(Material):
         'material_name',
         'shader_name'
     ]
+
+    @classmethod
+    def supported_texture_attributes(cls):
+        return cls.__texture_attributes
 
     @classmethod
     def supported_tensor_attributes(cls):
@@ -481,6 +499,34 @@ class PBRMaterial(Material):
 
     def __str__(self):
         return self.to_string()
+
+    def as_dict(self):
+        """Convert the PBRMaterial to a dictionary representation.
+        
+        Returns:
+            dict: Dictionary containing all material attributes
+        """
+        result = {'classname': 'pbr'}
+        
+        # Add all attributes that are set (not None)
+        for attr in PBRMaterial.__slots__:
+            value = getattr(self, attr)
+            if value is not None:
+                result[attr] = value
+                    
+        return result
+
+    @classmethod
+    def from_dict(cls, in_dict):
+        """Create a PBRMaterial from a dictionary representation.
+        
+        Args:
+            in_dict (dict): Dictionary containing material attributes
+            
+        Returns:
+            PBRMaterial: New PBRMaterial instance
+        """
+        return cls(**in_dict)
 
 
 # Useful for testing

--- a/tests/python/kaolin/render/camera/test_camera.py
+++ b/tests/python/kaolin/render/camera/test_camera.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,8 @@ import numpy as np
 import torch
 import kaolin
 from kaolin.render.camera import Camera
+from kaolin.render.camera.intrinsics_pinhole import PinholeIntrinsics
+from kaolin.render.camera.intrinsics_ortho import OrthographicIntrinsics
 from kaolin.utils.testing import FLOAT_TYPES
 
 
@@ -222,3 +224,129 @@ class TestViewportMatrix:
         assert (verts_in_frustum[:, 1] <= cam.height).all()
         assert (verts_in_frustum[:, 2] >= 0).all()
         assert (verts_in_frustum[:, 2] <= 1).all()
+
+
+class TestToFromDict:
+    def test_to_dict(self):
+        # Pinhole camera
+        cam_pinhole = Camera.from_args(
+            eye=torch.tensor([4.0, 4.0, 4.0]),
+            at=torch.tensor([0.0, 0.0, 0.0]),
+            up=torch.tensor([0.0, 1.0, 0.0]),
+            fov=30 * np.pi / 180,
+            width=400, height=300,
+            dtype=torch.float32, device='cpu',
+        )
+        d = cam_pinhole.as_dict()
+        assert d['intrinsics']['classname'] == 'pinhole'
+        assert d['intrinsics']['width'] == 400
+        assert d['intrinsics']['height'] == 300
+        assert 'focal_x' in d['intrinsics']
+        assert 'view_matrix' in d['extrinsics']
+        assert len(d['extrinsics']['view_matrix']) == 4
+
+        # Orthographic camera
+        cam_ortho = Camera.from_args(
+            eye=torch.tensor([1.0, 2.0, 3.0]),
+            at=torch.tensor([0.0, 0.0, 0.0]),
+            up=torch.tensor([0.0, 1.0, 0.0]),
+            width=640, height=480,
+            fov_distance=2.0,
+            dtype=torch.float32, device='cpu',
+        )
+        d_ortho = cam_ortho.as_dict()
+        assert d_ortho['intrinsics']['classname'] == 'orthographic'
+        assert d_ortho['intrinsics']['width'] == 640
+        assert d_ortho['intrinsics']['fov_distance'] == 2.0
+        assert 'view_matrix' in d_ortho['extrinsics']
+
+    def test_from_dict(self):
+        # Pinhole camera from dict
+        pinhole_dict = {
+            'intrinsics': {
+                'classname': 'pinhole',
+                'width': 320, 'height': 240,
+                'focal_x': 300.0, 'focal_y': 300.0,
+                'x0': 0.0, 'y0': 0.0,
+                'near': 0.01, 'far': 100.0,
+            },
+            'extrinsics': {
+                'view_matrix': [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, -5], [0, 0, 0, 1]],
+            },
+        }
+        cam = Camera.from_dict(pinhole_dict)
+        assert isinstance(cam.intrinsics, PinholeIntrinsics)
+        assert cam.width == 320
+        assert cam.height == 240
+        assert cam.near == 0.01
+
+        # Orthographic camera from dict
+        ortho_dict = {
+            'intrinsics': {
+                'classname': 'orthographic',
+                'width': 640, 'height': 480,
+                'fov_distance': 1.5,
+                'near': 0.1, 'far': 500.0,
+            },
+            'extrinsics': {
+                'view_matrix': [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, -3], [0, 0, 0, 1]],
+            },
+        }
+        cam_ortho = Camera.from_dict(ortho_dict)
+        assert isinstance(cam_ortho.intrinsics, OrthographicIntrinsics)
+        assert cam_ortho.width == 640
+        assert torch.allclose(cam_ortho.fov_distance, torch.tensor(1.5))
+
+    def test_round_trip(self):
+        # Spot checks only: correct subclass and a couple of properties after round-trip.
+        # Detailed to/from dict behavior is tested in test_pinhole and test_ortho.
+        cameras = [
+            # Pinhole from fov
+            Camera.from_args(
+                eye=torch.tensor([4.0, 4.0, 4.0]),
+                at=torch.tensor([0.0, 0.0, 0.0]),
+                up=torch.tensor([0.0, 1.0, 0.0]),
+                fov=30 * np.pi / 180,
+                width=320, height=240,
+                dtype=torch.float32, device='cpu',
+            ),
+            # Pinhole with principal point offset
+            Camera.from_args(
+                eye=torch.tensor([1.0, 2.0, 3.0]),
+                at=torch.tensor([0.0, 0.0, 0.0]),
+                up=torch.tensor([0.0, 1.0, 0.0]),
+                fov=np.pi / 4,
+                x0=10.0, y0=20.0,
+                width=800, height=600,
+                dtype=torch.float64, device='cpu',
+            ),
+            # Orthographic
+            Camera.from_args(
+                eye=torch.tensor([0.0, 5.0, 0.0]),
+                at=torch.tensor([0.0, 0.0, 0.0]),
+                up=torch.tensor([0.0, 0.0, -1.0]),
+                width=400, height=300,
+                fov_distance=2.0,
+                near=-50.0, far=100.0,
+                dtype=torch.float32, device='cpu',
+            ),
+        ]
+        expected_classes = [PinholeIntrinsics, PinholeIntrinsics, OrthographicIntrinsics]
+        expected_classnames = ['pinhole', 'pinhole', 'orthographic']
+
+        for cam, expected_cls, expected_name in zip(cameras, expected_classes, expected_classnames):
+            d = cam.as_dict()
+            assert d['intrinsics']['classname'] == expected_name
+            assert 'view_matrix' in d['extrinsics']
+
+            cam2 = Camera.from_dict(d)
+            assert isinstance(cam2.intrinsics, expected_cls)
+            assert cam2.width == cam.width
+            assert cam2.height == cam.height
+            assert cam2.near == cam.near
+            assert cam2.far == cam.far
+            assert torch.allclose(
+                cam2.extrinsics.view_matrix().cpu().float(),
+                cam.extrinsics.view_matrix().cpu().float(),
+                atol=1e-5,
+            )

--- a/tests/python/kaolin/render/camera/test_extrinsics.py
+++ b/tests/python/kaolin/render/camera/test_extrinsics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -654,7 +654,7 @@ class TestCameraExtrinsicsParams:
                                                   requires_grad=True, backend=backend)
         num_cams = sample_lookat_data['view_matrix'].shape[0]
         original_matrix = extrinsics.view_matrix()
-        target_matrix = torch.eye(4).to(device, dtype)
+        target_matrix = torch.eye(4).to(device, dtype).unsqueeze(0).expand(num_cams, -1, -1)
 
         optimizer = torch.optim.SGD([extrinsics.parameters()], lr=0.001, momentum=0.9)
         criterion = torch.nn.functional.mse_loss
@@ -679,7 +679,8 @@ class TestCameraExtrinsicsParams:
         extrinsics = CameraExtrinsics.from_lookat(eye, at, up, device=device, dtype=dtype,
                                                   requires_grad=False, backend=backend)
         original_matrix = extrinsics.view_matrix()
-        target_matrix = torch.eye(4).to(device, dtype)
+        num_cams = original_matrix.shape[0]
+        target_matrix = torch.eye(4).to(device, dtype).unsqueeze(0).expand(num_cams, -1, -1)
         optimizer = torch.optim.SGD([extrinsics.parameters()], lr=0.001, momentum=0.9)
         criterion = torch.nn.functional.mse_loss
         for i in range(5):
@@ -746,7 +747,7 @@ class TestCameraExtrinsicsTranslate:
 
         view_matrix = cam_pos_data['view_matrix'].to(device, dtype)
         translate_amnt = view_matrix.new_tensor([0.1, 1.0, 10.0])
-        cam_pos = torch.tensor(cam_pos, device=device, dtype=dtype)
+        cam_pos = torch.as_tensor(cam_pos, device=device, dtype=dtype)
         shifted_pos = cam_pos.squeeze(-1) + translate_amnt.to(cam_pos.device)
         translated_extrinsics = CameraExtrinsics.from_camera_pose(shifted_pos, cam_dir,
                                                                   dtype=dtype, device=device, backend=backend)
@@ -1012,7 +1013,7 @@ class TestCameraExtrinsicsCamPosDir:
         extrinsics = CameraExtrinsics.from_camera_pose(
             cam_pos, cam_dir, device=device, dtype=dtype, backend=backend)
         num_cams = view_matrix.shape[0]
-        expected = torch.tensor(cam_pos, device=device, dtype=dtype)
+        expected = torch.as_tensor(cam_pos, device=device, dtype=dtype)
         expected = expected.reshape(num_cams, 3, 1)
         extrinsics_result = extrinsics.cam_pos()
         assert torch.allclose(extrinsics_result, expected, rtol=1e-3, atol=1e-2)
@@ -1025,7 +1026,7 @@ class TestCameraExtrinsicsCamPosDir:
         extrinsics = CameraExtrinsics.from_camera_pose(
             cam_pos, cam_dir, device=device, dtype=dtype, backend=backend)
         num_cams = view_matrix.shape[0]
-        cam_dir = torch.tensor(cam_dir, device=device, dtype=dtype)
+        cam_dir = torch.as_tensor(cam_dir, device=device, dtype=dtype)
         if cam_dir.ndim == 2:
             cam_dir = cam_dir.unsqueeze(0)
 
@@ -1042,7 +1043,7 @@ class TestCameraExtrinsicsCamPosDir:
         extrinsics = CameraExtrinsics.from_camera_pose(
             cam_pos, cam_dir, device=device, dtype=dtype, backend=backend)
         num_cams = view_matrix.shape[0]
-        cam_dir = torch.tensor(cam_dir, device=device, dtype=dtype)
+        cam_dir = torch.as_tensor(cam_dir, device=device, dtype=dtype)
         if cam_dir.ndim == 2:
             cam_dir = cam_dir.unsqueeze(0)
         expected = cam_dir[:, :, 1]
@@ -1058,7 +1059,7 @@ class TestCameraExtrinsicsCamPosDir:
         extrinsics = CameraExtrinsics.from_camera_pose(
             cam_pos, cam_dir, device=device, dtype=dtype, backend=backend)
         num_cams = view_matrix.shape[0]
-        cam_dir = torch.tensor(cam_dir, device=device, dtype=dtype)
+        cam_dir = torch.as_tensor(cam_dir, device=device, dtype=dtype)
         if cam_dir.ndim == 2:
             cam_dir = cam_dir.unsqueeze(0)
         expected = cam_dir[:, :, 2]
@@ -1067,3 +1068,56 @@ class TestCameraExtrinsicsCamPosDir:
         assert torch.allclose(extrinsics_result, expected, rtol=1e-3, atol=1e-3)
         assert extrinsics_result.shape == (num_cams, 3, 1)
 
+class TestToFromDict:
+    def test_from_dict(self):
+        # Construct input dict matching as_dict() output; check view_matrix after from_dict.
+        view_matrix = [[1.0, 0.0, 0.0, 0.0],
+                      [0.0, 1.0, 0.0, 0.0],
+                      [0.0, 0.0, 1.0, -2.0],
+                      [0.0, 0.0, 0.0, 1.0]]
+        in_dict = {'view_matrix': view_matrix}
+        extrinsics = CameraExtrinsics.from_dict(in_dict)
+        expected = torch.tensor(view_matrix)
+        assert torch.allclose(extrinsics.view_matrix().squeeze(0), expected)
+
+    def test_to_dict(self):
+        # Create extrinsics, as_dict must contain matching view_matrix.
+        view_matrix = torch.tensor(
+            [[[-1.0, 0.0, 0.0, 0.0],
+              [0.0, 1.0, 0.0, 0.0],
+              [0.0, 0.0, -1.0, -3.0],
+              [0.0, 0.0, 0.0, 1.0]]],
+            dtype=torch.float32,
+        )
+        extrinsics = CameraExtrinsics.from_view_matrix(view_matrix)
+        d = extrinsics.as_dict()
+        assert 'view_matrix' in d
+        assert torch.allclose(
+            extrinsics.view_matrix().squeeze(0),
+            torch.tensor(d['view_matrix']),
+        )
+
+    def test_round_trip(self):
+        # Round-trip 3 extrinsics through as_dict / from_dict; view_matrix must match.
+        view_matrices = [
+            torch.tensor([[1.0, 0.0, 0.0, 0.0],
+                         [0.0, 1.0, 0.0, 0.0],
+                         [0.0, 0.0, 1.0, -2.0],
+                         [0.0, 0.0, 0.0, 1.0]], dtype=torch.float32),
+            torch.tensor([[-1.0, 0.0, 0.0, 0.0],
+                         [0.0, 1.0, 0.0, 0.0],
+                         [0.0, 0.0, -1.0, -5.0],
+                         [0.0, 0.0, 0.0, 1.0]], dtype=torch.float32),
+            torch.tensor([[0.0, -1.0, 0.0, 1.0],
+                         [1.0, 0.0, 0.0, 0.0],
+                         [0.0, 0.0, 1.0, -1.0],
+                         [0.0, 0.0, 0.0, 1.0]], dtype=torch.float32),
+        ]
+        for vm in view_matrices:
+            extrinsics = CameraExtrinsics.from_view_matrix(vm.unsqueeze(0))
+            d = extrinsics.as_dict()
+            extrinsics2 = CameraExtrinsics.from_dict(d)
+            assert torch.allclose(
+                extrinsics2.view_matrix().squeeze(0),
+                extrinsics.view_matrix().squeeze(0),
+            )

--- a/tests/python/kaolin/render/camera/test_ortho.py
+++ b/tests/python/kaolin/render/camera/test_ortho.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import pytest
+import itertools
+import numpy as np
+import torch
+
+from kaolin.render.camera import Camera
+from kaolin.render.camera.intrinsics_ortho import OrthographicIntrinsics
+from kaolin.utils.testing import FLOAT_TYPES, ALL_DEVICES, contained_torch_equal
+
+
+class TestToFromDict:
+    def test_from_dict(self):
+        in_dict = {
+                'width': 100,
+                'height': 200,
+                'fov_distance': 1.5,
+                'near': 0.1,
+                'far': 500.0,
+            }
+        expected_intrinsics = OrthographicIntrinsics.from_frustum(**in_dict)
+
+        intrinsics = OrthographicIntrinsics.from_dict(in_dict)
+        in_dict['classname'] = 'orthographic'
+        intrinsics2 = OrthographicIntrinsics.from_dict(in_dict)
+
+        assert contained_torch_equal(intrinsics, expected_intrinsics)
+        assert contained_torch_equal(intrinsics2, expected_intrinsics)
+
+    def test_to_dict(self):
+        intrinsics = OrthographicIntrinsics.from_frustum(
+            width=400,
+            height=300,
+            fov_distance=2.0,
+            near=-100.0,
+            far=200.0,
+            device='cpu',
+            dtype=torch.float32,
+        )
+        intrinsics_dict = intrinsics.as_dict()
+        assert intrinsics_dict['classname'] == 'orthographic'
+        assert intrinsics_dict['width'] == 400
+        assert intrinsics_dict['height'] == 300
+        assert intrinsics_dict['fov_distance'] == 2.0
+        assert intrinsics_dict['near'] == -100.0
+        assert intrinsics_dict['far'] == 200.0
+
+        intrinsics_default = OrthographicIntrinsics.from_frustum(
+            width=256,
+            height=256,
+            fov_distance=1.0,
+            device='cpu',
+            dtype=torch.float32,
+        )
+        intrinsics_default_dict = intrinsics_default.as_dict()
+        assert intrinsics_default_dict['classname'] == 'orthographic'
+        assert intrinsics_default_dict['width'] == intrinsics_default.width
+        assert intrinsics_default_dict['height'] == intrinsics_default.height
+        assert intrinsics_default_dict['fov_distance'] == intrinsics_default.fov_distance.item()
+        assert intrinsics_default_dict['near'] == intrinsics_default.near
+        assert intrinsics_default_dict['far'] == intrinsics_default.far
+
+    def test_round_trip(self):
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+        intrinsics_all = [
+            OrthographicIntrinsics.from_frustum(
+                width=320, height=240, fov_distance=1.0,
+                device=device, dtype=torch.float32,
+            ),
+            OrthographicIntrinsics.from_frustum(
+                width=800, height=600, fov_distance=0.5,
+                near=-50.0, far=100.0,
+                device='cpu'
+            ),
+            OrthographicIntrinsics.from_frustum(
+                width=100, height=100, fov_distance=1.2,
+                near=0.01, far=2000.0,
+                device='cpu', dtype=torch.float32,
+            ),
+        ]
+
+        for intrinsics in intrinsics_all:
+            param_dict = intrinsics.as_dict()
+            reconstructed = OrthographicIntrinsics.from_dict(param_dict).to(intrinsics.device)
+            param_dict2 = reconstructed.as_dict()
+
+            assert contained_torch_equal(intrinsics, reconstructed)
+            assert contained_torch_equal(param_dict, param_dict2)
+
+            assert torch.allclose(reconstructed.params.to(device), intrinsics.params.to(device))
+            assert reconstructed.width == intrinsics.width
+            assert reconstructed.height == intrinsics.height
+            assert reconstructed.near == intrinsics.near
+            assert reconstructed.far == intrinsics.far
+            assert reconstructed.fov_distance == intrinsics.fov_distance

--- a/tests/python/kaolin/render/camera/test_pinhole.py
+++ b/tests/python/kaolin/render/camera/test_pinhole.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,8 +19,9 @@ import itertools
 import numpy as np
 import torch
 import kaolin
-from kaolin.render.camera import Camera
-from kaolin.utils.testing import FLOAT_TYPES
+from kaolin.render.camera import Camera, CameraExtrinsics
+from kaolin.render.camera.intrinsics_pinhole import PinholeIntrinsics
+from kaolin.utils.testing import FLOAT_TYPES, contained_torch_equal
 
 _CAM_DATA_IDX = (0, 1, 2, 3, 4)
 
@@ -189,3 +190,110 @@ class TestPinhole:
         assert (torch.allclose(cam.focal_y, (focal_y / 2), rtol=1e-3))
         assert (cam.width == width)
         assert (cam.height == (height * 0.5))
+
+
+class TestToFromDict:
+    def test_from_dict(self):
+        in_dict = {
+                'width': 100,
+                'height': 200,
+                'focal_x': 80.0,
+                'focal_y': 80.0,
+                'x0': 5.0,
+                'y0': 10.0,
+                'near': 0.1,
+                'far': 500.0,
+            }
+        expected_intrinsics = PinholeIntrinsics.from_focal(**in_dict)
+
+        intrinsics = PinholeIntrinsics.from_dict(in_dict)
+        in_dict['classname'] = 'pinhole'
+        intrinsics2 = PinholeIntrinsics.from_dict(in_dict)
+
+        assert contained_torch_equal(intrinsics, expected_intrinsics)
+        assert contained_torch_equal(intrinsics2, expected_intrinsics)
+
+
+    def test_to_dict(self):
+        intrinsics = PinholeIntrinsics.from_focal(
+            width=400,
+            height=300,
+            focal_x=400.0,
+            focal_y=400.0,
+            x0=10.0,
+            y0=20.0,
+            near=0.5,
+            far=200.0,
+            device='cpu',
+            dtype=torch.float32,
+        )
+        intrinsics_dict = intrinsics.as_dict()
+        assert intrinsics_dict['classname'] == 'pinhole'
+        assert intrinsics_dict['width'] == 400
+        assert intrinsics_dict['height'] == 300
+        assert intrinsics_dict['x0'] == 10.0
+        assert intrinsics_dict['y0'] == 20.0
+        assert intrinsics_dict['near'] == 0.5
+        assert intrinsics_dict['far'] == 200.0
+        assert 'focal_x' in intrinsics_dict and 'focal_y' in intrinsics_dict
+
+        # Camera with default properties; dict should still be valid and round-trippable.
+        intrinsics_default = PinholeIntrinsics.from_fov(
+            width=256,
+            height=256,
+            fov=np.pi / 4,
+            device='cpu',
+            dtype=torch.float32,
+        )
+        intrinsics_default_dict = intrinsics_default.as_dict()
+        assert intrinsics_default_dict['classname'] == 'pinhole'
+        assert intrinsics_default_dict['width'] == intrinsics_default.width
+        assert intrinsics_default_dict['height'] == intrinsics_default.height
+        assert intrinsics_default_dict['focal_x'] == intrinsics_default.focal_x
+        assert intrinsics_default_dict['focal_y'] == intrinsics_default.focal_y
+        assert intrinsics_default_dict['x0'] == intrinsics_default.x0
+        assert intrinsics_default_dict['y0'] == intrinsics_default.y0
+        assert intrinsics_default_dict['near'] == intrinsics_default.near
+        assert intrinsics_default_dict['far'] == intrinsics_default.far
+
+    def test_round_trip(self):
+        # Round-trip 3 single cameras through as_dict / from_dict; properties must match.
+        # Config 1
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+        intrinsics_all = [PinholeIntrinsics.from_fov(
+            width=320, height=240, fov=30 * np.pi / 180,
+            device=device, dtype=torch.float32,  # we'll use mixed devices
+        ),
+        # Config 2
+        PinholeIntrinsics.from_fov(
+            width=800, height=600, fov=np.pi / 6,
+            x0=50.0, y0=25.0,
+            device='cpu'
+        ),
+        # Config 3: from_focal (focal-length-based) for round-trip coverage
+        PinholeIntrinsics.from_focal(
+            width=640, height=480,
+            focal_x=520.0, focal_y=510.0,
+            x0=15.0, y0=20.0,
+            near=0.01, far=2000.0,
+            device='cpu'
+        )]
+
+        for intrinsics in intrinsics_all:
+            param_dict = intrinsics.as_dict()
+            reconstructed = PinholeIntrinsics.from_dict(param_dict).to(intrinsics.device)
+            param_dict2 = reconstructed.as_dict()
+
+            assert contained_torch_equal(intrinsics, reconstructed)
+            assert contained_torch_equal(param_dict, param_dict2)
+
+            assert torch.allclose(reconstructed.params.to(device), intrinsics.params.to(device))
+            assert reconstructed.width == intrinsics.width
+            assert reconstructed.height == intrinsics.height
+            assert reconstructed.near == intrinsics.near
+            assert reconstructed.far == intrinsics.far
+            assert reconstructed.x0 == intrinsics.x0
+            assert reconstructed.y0 == intrinsics.y0
+            assert reconstructed.focal_x == intrinsics.focal_x
+            assert reconstructed.focal_y == intrinsics.focal_y

--- a/tests/python/kaolin/render/test_materials.py
+++ b/tests/python/kaolin/render/test_materials.py
@@ -275,3 +275,69 @@ class TestPBRMaterial:
                 assert att in str_mat_partial, f'Missing {att} in {str_mat}'
             else:
                 assert f' {att}:' not in str_mat_partial, f'Should not print missing {att} in {str_mat}'
+
+    def test_to_from_dict(self):
+        """Test material serialization to/from dictionary."""
+        material_name = 'test_material'
+        
+        # Create a material with all attributes
+        input_attr = random_material_values()
+        input_attr.update(random_material_textures())
+        input_attr.update(random_material_colorspaces())
+        input_attr['material_name'] = material_name
+        
+        mat = PBRMaterial(**input_attr)
+        
+        # Convert to dict
+        mat_dict = mat.as_dict()
+        
+        # Check that dict contains expected keys
+        assert 'classname' in mat_dict
+        assert mat_dict['classname'] == 'pbr'
+        assert 'material_name' in mat_dict
+        assert mat_dict['material_name'] == material_name
+        
+        # Check that all non-None attributes are in the dict
+        for attr in mat.get_attributes():
+            assert attr in mat_dict, f"Attribute {attr} not found in dict"
+            # For tensors, verify they are the same object (not copied)
+            if torch.is_tensor(getattr(mat, attr)):
+                assert torch.equal(mat_dict[attr], getattr(mat, attr))
+        
+        # Test round-trip: material -> dict -> material
+        mat_reconstructed = PBRMaterial.from_dict({k: v for k, v in mat_dict.items() if k != 'classname'})
+        assert contained_torch_equal(mat, mat_reconstructed, approximate=True, print_error_context='round-trip')
+        
+        # Test round-trip via Material base class
+        from kaolin.render.materials import Material
+        mat_reconstructed2 = Material.from_dict(mat_dict)
+        assert contained_torch_equal(mat, mat_reconstructed2, approximate=True, print_error_context='base class round-trip')
+        
+        # Verify dict -> material -> dict produces same dict
+        mat_dict2 = mat_reconstructed.as_dict()
+        assert contained_torch_equal(mat_dict, mat_dict2, approximate=True, print_error_context='dict round-trip')
+        
+        # Test with partial material (only some attributes)
+        partial_material_name = 'simple_material'
+        partial_input = {
+            'diffuse_color': (0.8, 0.2, 0.3),
+            'roughness_value': 0.5,
+            'diffuse_texture': torch.rand((256, 256, 3)),
+            'material_name': partial_material_name
+        }
+        
+        mat_partial = PBRMaterial(**partial_input)
+        mat_partial_dict = mat_partial.as_dict()
+        
+        # Check that only set attributes are in dict
+        assert 'diffuse_color' in mat_partial_dict
+        assert 'roughness_value' in mat_partial_dict
+        assert 'diffuse_texture' in mat_partial_dict
+        assert 'material_name' in mat_partial_dict
+        # metallic_value should not be in dict (it's None)
+        assert 'metallic_value' not in mat_partial_dict or mat_partial_dict['metallic_value'] is None
+        
+        # Round-trip with partial material via Material base class
+        mat_partial_reconstructed = Material.from_dict(mat_partial_dict)
+        assert contained_torch_equal(mat_partial, mat_partial_reconstructed, approximate=True, 
+                                    print_error_context='partial round-trip')


### PR DESCRIPTION
Easy as_dict, from_dict simplifies saving, loading, and sending (e.g. as JSON, YAML) components across various research pipelines.