### PR TITLE
Fixing nvdiffrast usage with their last update. Also fix windows CI build pipeline.

### DIFF
--- a/ci/gitlab_jenkins_templates/core_ci.jenkins
+++ b/ci/gitlab_jenkins_templates/core_ci.jenkins
@@ -12,12 +12,12 @@ def defaultWheelsPythonVers = ['3.9', '3.10', '3.11', '3.12']
 def ubuntu_from_pytorch_configs = [
     [
         // python: 3.10
-        'cudaVer': '11.8', 'cudnnVer': '8', 'torchVer': '2.3.0',
+        'cudaVer': '11.8', 'cudnnVer': '9', 'torchVer': '2.5.0',
         'archsToTest': 'MULTI'
     ],
     [
         // python: 3.11
-        'cudaVer': '12.8', 'cudnnVer': '9', 'torchVer': '2.7.1',
+        'cudaVer': '13.0', 'cudnnVer': '9', 'torchVer': '2.10.0',
         'archsToTest': 'MULTI'
     ]
 ]
@@ -40,12 +40,12 @@ def ubuntu_from_nvcr_configs = [
 def ubuntu_from_cuda_configs = [
     [
         'cudaVer': '11.8.0', 'cudnnVer': '8',
-        'pythonVer': '3.9', 'torchVer': '2.3.0',
+        'pythonVer': '3.9', 'torchVer': '2.5.0',
         'archsToTest': 'MULTI'
     ],
     [
-        'cudaVer': '12.1.0', 'cudnnVer': '8',
-        'pythonVer': '3.12', 'torchVer': '2.7.1',
+        'cudaVer': '13.0.1', 'cudnnVer': '',
+        'pythonVer': '3.12', 'torchVer': '2.10.0',
         'archsToTest': 'MULTI'
     ],
 ]
@@ -54,10 +54,10 @@ def ubuntu_from_cuda_configs = [
 // (Use docker image ubuntu:18.04 as a base)
 def ubuntu_cpuonly_configs = [
     [
-        'pythonVer': '3.9', 'torchVer': '2.3.0',
+        'pythonVer': '3.9', 'torchVer': '2.5.0',
     ],
     [
-        'pythonVer': '3.11', 'torchVer': '2.7.1',
+        'pythonVer': '3.12', 'torchVer': '2.10.0',
     ]
 ]
 
@@ -404,14 +404,38 @@ def windows_from_server_configs = [
 */
     [
         'cudaVer': '11.8',
-        'pythonVer': '3.9', 'torchVer': '2.3.0',
+        'pythonVer': '3.9', 'torchVer': '2.5.0',
         'archsToTest': ''
     ],
     [
-        'cudaVer': '12.6',
-        'pythonVer': '3.12', 'torchVer': '2.7.1',
+        'cudaVer': '13.0',
+        'pythonVer': '3.12', 'torchVer': '2.10.0',
         'archsToTest': ''
     ],
+]
+
+def windows_base_configs = [
+    [
+        'cudaVer': '11.8',
+    ],
+    [
+        'cudaVer': '12.1',
+    ],
+    [
+        'cudaVer': '12.4',
+    ],
+    [
+        'cudaVer': '12.6',
+    ],
+    [
+        'cudaVer': '12.8',
+    ],
+    [
+        'cudaVer': '12.9',
+    ],
+    [
+        'cudaVer': '13.0',
+    ]
 ]
 
 dockerRegistryServer = 'gitlab-master.nvidia.com:5005'
@@ -427,7 +451,6 @@ node {
     // To enable master branch we have to accept all the push requests
     // and prune them here.
     sh "echo ${gitlabActionType}"
-    jobMap = [:]
     // Jenkins doesn't parse the commit hash from the webhook.
     // So we need to get the commit hash from the last commit in the branch,
     // So we unsure that all the build and run are on the same commit
@@ -438,8 +461,13 @@ node {
     commitHash = sh(script: "git log -1 --pretty=format:%h",
                     returnStdout: true).trim()
     sh "echo ${commitHash}"
+    def hasForWindowsBaseInCommit = sh(script: "git log -1 | grep '.*\\[for windows base\\].*'",
+                                       returnStatus: true)
+    def hasPushWindowsBaseInCommit = sh(script: "git log -1 | grep '.*\\[push windows base\\].*'",
+                                        returnStatus: true)
     if (gitlabActionType == "MERGE" &&
         gitlabMergeRequestTitle.contains("[for wheels]")) {
+            jobMap = [:]
             for (config in ubuntu_for_cuda_wheels_configs) {
                 pythonVers = config.containsKey('pythonVers') && config.containsKey != '' ? config['pythonVers'] : defaultWheelsPythonVers
                 for (pythonVer in pythonVers) {
@@ -503,7 +531,53 @@ node {
                     )
                 }
             }
+        stage('Launch builds') {
+            parallel jobMap
+        }
+
+    } else if (hasForWindowsBaseInCommit == 0) {
+        buildWindowsBaseJobMap = [:]
+        for (config in windows_base_configs) {
+            def cudaVerLabel = config['cudaVer'].split('\\.').join('')
+            def configName = "windows-base-cuda${cudaVerLabel}"
+            buildWindowsBaseJobMap["${configName}"] = prepareWindowsBaseJob(
+                configName,
+                config['cudaVer'],
+            )
+        }
+        stage('Launch windows base builds') {
+            parallel buildWindowsBaseJobMap
+        }
+
+    } else if (hasPushWindowsBaseInCommit == 0) {
+        def registryImagePath = imageBaseTag.substring(dockerRegistryServer.length() + 1)
+        stage('Promote windows base images to master') {
+            withCredentials([usernamePassword(credentialsId: 'kaolin-gitlab-access-token-as-password',
+                                              usernameVariable: 'REG_USER', passwordVariable: 'REG_PASS')]) {
+                for (config in windows_base_configs) {
+                    def branchTag = "windows-base-cuda${config['cudaVer']}-${branchRef}"
+                    def masterTag = "windows-base-cuda${config['cudaVer']}-master"
+                    sh """
+                        TOKEN=\$(curl -s -u \$REG_USER:\$REG_PASS \
+                            'https://gitlab-master.nvidia.com/jwt/auth?service=container_registry&scope=repository:${registryImagePath}:pull,push' \
+                            | sed 's/.*"token":"\\([^"]*\\)".*/\\1/')
+                        MANIFEST=\$(curl -s \
+                            -H "Authorization: Bearer \$TOKEN" \
+                            -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+                            "https://${dockerRegistryServer}/v2/${registryImagePath}/manifests/${branchTag}")
+                        curl -s -X PUT \
+                            -H "Authorization: Bearer \$TOKEN" \
+                            -H 'Content-Type: application/vnd.docker.distribution.manifest.v2+json' \
+                            -d "\$MANIFEST" \
+                            "https://${dockerRegistryServer}/v2/${registryImagePath}/manifests/${masterTag}"
+                    """
+                }
+            }
+        }
+
     } else {
+        jobMap = [:]
+
         // Check if the last commit message has a [with custom] tag
         def hasNoCustomInMess = sh(script: "git log -1 | grep '.*\\[with custom\\].*'",
                                    returnStatus: true)
@@ -580,9 +654,9 @@ node {
                 false
             )
         }
-    }
-    stage('Launch builds') {
-        parallel jobMap
+        stage('Launch builds') {
+            parallel jobMap
+        }
     }
 }
 
@@ -678,6 +752,27 @@ def prepareUbuntuCPUOnlyJob(configName, pythonVer, torchVer, buildWheel) {
   }
 }
 
+def prepareWindowsBaseJob(configName, cudaVer) {
+  return {
+    stage("${configName}") {
+      updateGitlabCommitStatus(name: "build-windows-base-cuda${cudaVer}", state: "pending")
+      build job: "windows_base_build_template_CI",
+      parameters: [
+        string(name: 'configName', value: "${configName}"),
+        string(name: 'cudaVer', value: "${cudaVer}"),
+        string(name: 'targetImageTag',
+               value: "${imageBaseTag}:windows-base-cuda${cudaVer}-${branchRef}"),
+        string(name: 'sourceBranch', value: "${gitlabSourceBranch}"),
+        string(name: 'repoUrl', value: "${scm.userRemoteConfigs[0].url}"),
+        string(name: 'commitHash', value: "${commitHash}")
+      ],
+      wait: true,
+      propagate: true
+    }
+  }
+}
+
+
 def prepareWindowsCUDAJob(configName, cudaVer, pythonVer, torchVer, archsToTest,
                           buildWheel) {
   return {
@@ -685,11 +780,28 @@ def prepareWindowsCUDAJob(configName, cudaVer, pythonVer, torchVer, archsToTest,
       updateGitlabCommitStatus(name: "build-${configName}", state: "pending")
       if (buildWheel.toBoolean()) {
         updateGitlabCommitStatus(name: "test-${configName}", state: "pending")
-      } //else {
-      //  for (arch in archsToTest.split(';')) {
-      //    updateGitlabCommitStatus(name: "test-${configName}-${arch}", state: "pending")
-      //  }
-      //}
+      }
+      def branchBaseImage = "${imageBaseTag}:windows-base-cuda${cudaVer}-${branchRef}"
+      def masterBaseImage = "${imageBaseTag}:windows-base-cuda${cudaVer}-master"
+      def windowsBaseImage
+      def registryImagePath = imageBaseTag.substring(dockerRegistryServer.length() + 1)
+      def branchTag = "windows-base-cuda${cudaVer}-${branchRef}"
+      withCredentials([usernamePassword(credentialsId: 'kaolin-gitlab-access-token-as-password',
+                                        usernameVariable: 'REG_USER', passwordVariable: 'REG_PASS')]) {
+        def statusCode = sh(
+          script: """
+              TOKEN=\$(curl -s -u \$REG_USER:\$REG_PASS \
+                  'https://gitlab-master.nvidia.com/jwt/auth?service=container_registry&scope=repository:toronto_dl_lab/kaolin/kaolin:pull' \
+                  | sed 's/.*"token":"\\([^"]*\\)".*/\\1/')
+              curl -s -o /dev/null -w '%{http_code}' \
+                  -H "Authorization: Bearer \$TOKEN" \
+                  -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+                  "https://gitlab-master.nvidia.com:5005/v2/toronto_dl_lab/kaolin/kaolin/manifests/windows-base-cuda${cudaVer}-${branchRef}"
+          """,
+          returnStdout: true
+        ).trim()
+        windowsBaseImage = (statusCode == '200') ? branchBaseImage : masterBaseImage
+      }
 
       build job: "windows_build_template_CI",
       parameters: [
@@ -697,6 +809,7 @@ def prepareWindowsCUDAJob(configName, cudaVer, pythonVer, torchVer, archsToTest,
         string(name: 'cudaVer', value: "${cudaVer}"),
         string(name: 'pythonVer', value: "${pythonVer}"),
         string(name: 'torchVer', value: "${torchVer}"),
+        string(name: 'windowsBaseImage', value: "${windowsBaseImage}"),
         string(name: 'targetImageTag',
                value: "${imageBaseTag}:${branchRef}-${BUILD_ID}-${configName}"),
         string(name: 'sourceBranch', value: "${gitlabSourceBranch}"),

--- a/ci/gitlab_jenkins_templates/windows_base_build_CI.jenkins
+++ b/ci/gitlab_jenkins_templates/windows_base_build_CI.jenkins
@@ -1,12 +1,27 @@
 #!/usr/bin/env groovy
 
+// Map from CUDA version to URL to obtain windows installer
+def cuda_version_url = [
+    // CUDA drivers on test machines only available for CUDA version >= 11.0
+    //  see: https://gitlab-master.nvidia.com/ipp/cloud-infra/blossom/dev/windows-gpu-pods/-/tree/master/ContainerDriverSetup
+    // test machines currently are the only option, named 'gpu_tester'
+    //      two machines exist, only the TITAN RTX will pass tests
+    '11.8': 'https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_522.06_windows.exe',
+    '12.1': 'https://developer.download.nvidia.com/compute/cuda/12.1.0/local_installers/cuda_12.1.0_531.14_windows.exe',
+    '12.4': 'https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_551.78_windows.exe',
+    '12.6': 'https://developer.download.nvidia.com/compute/cuda/12.6.3/local_installers/cuda_12.6.3_561.17_windows.exe',
+    '12.8': 'https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_12.8.1_572.61_windows.exe',
+    '12.9': 'https://developer.download.nvidia.com/compute/cuda/12.9.1/local_installers/cuda_12.9.1_576.57_windows.exe',
+    '13.0': 'https://developer.download.nvidia.com/compute/cuda/13.0.2/local_installers/cuda_13.0.2_windows.exe'
+]
+
 docker_registry_server = targetImageTag.split(':')[0..1].join(':')
 // This will be the "RUN" displayed on Blue Ocean
 currentBuild.displayName = targetImageTag.split(':')[2]
 // This will be the "MESSAGE" displayed on Blue Ocean
 currentBuild.description = sourceBranch + ': ' + commitHash
 
-gitlabCommitStatus("build-${configName}") {
+gitlabCommitStatus("build-windows-base-cuda${cudaVer}") {
 
 // TODO(cfujitsang): need to use a library to reduce boilerplate code
 def VM_LABEL = ''
@@ -116,7 +131,7 @@ spec:
           VM_LABEL = "${POD_LABEL}-VM"
           echo "Waiting for node with label ${VM_LABEL} to become available"
           try {
-              timeout(time: 30, unit: 'MINUTES') { // Set the timeout duration as needed
+              timeout(time: 60, unit: 'MINUTES') { // Set the timeout duration as needed
             waitUntil {
               def node = Jenkins.instance.nodes.find { it.nodeName == VM_LABEL }
               echo "${node}"
@@ -184,19 +199,16 @@ spec:
                     ])
             }
             docker.withRegistry("https://${docker_registry_server}", 'kaolin-gitlab-access-token-as-password') {
-              stage('Build image') {
-                targetImage = docker.build(
-                  "${targetImageTag}",
-                  """-m 32g --no-cache -f ./tools/windows/Dockerfile.install \
-                      --build-arg BASE_IMAGE=${windowsBaseImage} \
-                      --build-arg PYTHON_VERSION=${pythonVer} \
-                      --build-arg PYTORCH_VERSION=${torchVer} \
-                      --build-arg FORCE_CUDA=1 \
-                      --build-arg IGNORE_TORCH_VER=1 \
-                      .
-                  """)
-              }
-
+                stage('Build') {
+                  cudaUrl = cuda_version_url[cudaVer]
+                  targetImage = docker.build(
+                    "${targetImageTag}",
+                    """-m 32g --no-cache -f ./tools/windows/Dockerfile.base \
+                        --build-arg CUDA_VERSION=${cudaVer} \
+                        --build-arg CUDA_URL=${cudaUrl} \
+                        .
+                    """)
+                }
               stage('Push') {
                 targetImage.push()
               }
@@ -209,31 +221,59 @@ spec:
           } // Timeout
         } catch (e) {
           // In case of build failure, we need to update the following tests as we won't run them.
-          if (buildWheel.toBoolean()) {
-            updateGitlabCommitStatus(name: "test-${configName}", state: 'canceled')
-          } else {
-            for (arch in archsToTest.split(';')) {
-              updateGitlabCommitStatus(name: "test-${configName}-${arch}", state: 'canceled')
-            }
-          }
+          // TODO(cfujitsang)
           throw e
         } // Try/Catch
       }
-
-        stage('cleanup') {
-          container('vm-cleaner') {
-            script {
-              def jenkinsUrl = "${JENKINS_INSTANCE}"
-              def jenkinsCliJarUrl = "${jenkinsUrl}/jnlpJars/jenkins-cli.jar"
-              sh "curl -O ${jenkinsCliJarUrl} > /dev/null 2>&1"
-              withCredentials([usernamePassword(credentialsId: 'svc-blossom-creds', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                sh "echo 'Running command with password ********'"
-
-                sh "java -jar jenkins-cli.jar -s ${jenkinsUrl} -auth ${USERNAME}:${PASSWORD} delete-node ${VM_LABEL}"
-              }
+stage('cleanup') {
+    podTemplate(
+        cloud: 'nvks-prod',
+        yaml: """
+apiVersion: v1
+kind: Pod
+spec:
+  restartPolicy: Never
+  containers:
+  - name: jnlp
+    image: jenkins/inbound-agent:4.11-1-jdk11  # ← correct image
+    resources:
+      requests:
+        memory: "256Mi"
+        cpu: "100m"
+  - name: vm-cleaner
+    image: maven:3.6.3-jdk-11               # ← maven goes here
+    command: ["sh", "-c", "sleep infinity"]
+    resources:
+      requests:
+        memory: "256Mi"
+        cpu: "100m"
+  nodeSelector:
+    kubernetes.io/os: linux
+    nvidia.com/node_type: builder
+"""
+    ) {
+        node(POD_LABEL) {
+            container('vm-cleaner') {
+                script {
+                    def jenkinsUrl = "https://prod.blsm.nvidia.com/kaolin-gitlab-ci"
+                    sh "curl -O ${jenkinsUrl}/jnlpJars/jenkins-cli.jar"
+                    withCredentials([usernamePassword(
+                        credentialsId: 'svc-blossom-creds',
+                        usernameVariable: 'USERNAME',
+                        passwordVariable: 'PASSWORD'
+                    )]) {
+                        sh """
+                            java -jar jenkins-cli.jar \
+                                -s ${jenkinsUrl} \
+                                -auth \$USERNAME:\$PASSWORD \
+                                delete-node ${VM_LABEL}
+                        """
+                    }
+                }
             }
-          }
         }
+    }
+}
     }
   }
 }

--- a/docs/notes/pbr_shader.rst
+++ b/docs/notes/pbr_shader.rst
@@ -62,9 +62,7 @@ A Note on the Backends
 ======================
 
 See :ref:`Differentiable Rendering <diff_render>` for background on different backends. As noted above, the :any:`easy_render.render_mesh <kaolin.render.easy_render.render_mesh>`
-supports two back ends. We recommend using `nvdiffrast <https://github.com/NVlabs/nvdiffrast>`_. If this library is installed, a default OpenGL based context will be created
-and reused on the provided GPU device. It is also possible to pass in the desirable context, or to configure the behavior of devault context constructions through
-methods like :any:`nvdiffrast_use_cuda() <kaolin.render.mesh.nvdiffrast_context.nvdiffrast_use_cuda>`. See :py:mod:`kaolin.render.mesh.nvdiffrast_context`.
+supports two back ends. We recommend using `nvdiffrast <https://github.com/NVlabs/nvdiffrast>`_. If this library is installed, a default CUDA based context will be created and reused on the provided GPU device.
 Note that not all nvdiffrast capabilities (like anti-aliasing) are currently available through the high-level function.
 
 

--- a/kaolin/csrc/ops/conversions/mise/mise.cpp
+++ b/kaolin/csrc/ops/conversions/mise/mise.cpp
@@ -54,9 +54,9 @@ MISE::MISE(int32_t in_resolution_0, int32_t in_depth, double in_threshold) {
   GridPoint point;
   Vector3D loc;
 
-  for (int i = 0; i < resolution_0; i++) {
-    for (int j = 0; j < resolution_0; j++) {
-      for (int k = 0; k < resolution_0; k++) {
+  for (int32_t i = 0; i < resolution_0; i++) {
+    for (int32_t j = 0; j < resolution_0; j++) {
+      for (int32_t k = 0; k < resolution_0; k++) {
         loc = Vector3D(i * voxel_size_0, j * voxel_size_0, k * voxel_size_0);
         voxel = Voxel(loc, 0, true);
         TORCH_CHECK(voxels.size() == i * resolution_0 * resolution_0 + j * resolution_0 + k);
@@ -65,11 +65,11 @@ MISE::MISE(int32_t in_resolution_0, int32_t in_depth, double in_threshold) {
     }
   }
 
-  int resolution_1 = resolution_0 + 1;
+  int32_t resolution_1 = resolution_0 + 1;
   grid_points.reserve(resolution_1 * resolution_1 * resolution_1);
-  for (int i = 0; i < resolution_1; i++) {
-    for (int j = 0; j < resolution_1; j++) {
-      for (int k = 0; k < resolution_1; k++) {
+  for (int32_t i = 0; i < resolution_1; i++) {
+    for (int32_t j = 0; j < resolution_1; j++) {
+      for (int32_t k = 0; k < resolution_1; k++) {
         loc = Vector3D(i * voxel_size_0, j * voxel_size_0, k * voxel_size_0);
         TORCH_CHECK(grid_points.size() == i * resolution_1 * resolution_1 + j * resolution_1 + k);
         add_grid_point(loc);
@@ -81,12 +81,12 @@ MISE::MISE(int32_t in_resolution_0, int32_t in_depth, double in_threshold) {
 void MISE::update(at::Tensor points, at::Tensor values) {
   TORCH_CHECK(points.size(0) == values.size(0));
   TORCH_CHECK(points.size(1) == 3);
-  long* points_ptr = points.data_ptr<long>();
+  int64_t* points_ptr = points.data_ptr<int64_t>();
   double* values_ptr = values.data_ptr<double>();
   Vector3D loc;
-  long idx;
+  int64_t idx;
 
-  for (int i = 0; i < points.size(0); i++) {
+  for (int32_t i = 0; i < points.size(0); i++) {
     loc = Vector3D(points_ptr[i * 3], points_ptr[i * 3 + 1], points_ptr[i * 3 + 2]);
     idx = get_grid_point_idx(loc);
     if (idx == -1)
@@ -98,7 +98,7 @@ void MISE::update(at::Tensor points, at::Tensor values) {
 }
 
 at::Tensor MISE::query() {
-  int n_unknown = 0;
+  int32_t n_unknown = 0;
   for (auto p : grid_points) {
     if (!p.known)
       n_unknown += 1;
@@ -107,7 +107,7 @@ at::Tensor MISE::query() {
   at::Tensor points = at::zeros({n_unknown, 3}, std::nullopt, at::kLong,
                                 std::nullopt, at::kCPU, std::nullopt);
   auto points_ptr = points.data_ptr<int64_t>();
-  int idx = 0;
+  int32_t idx = 0;
   for (auto p : grid_points) {
     if (!p.known) {
       points_ptr[idx * 3 + 0] = p.loc.x;
@@ -120,34 +120,34 @@ at::Tensor MISE::query() {
 }
 
 at::Tensor MISE::to_dense() {
-  int resolution_1 = resolution + 1;
+  int32_t resolution_1 = resolution + 1;
   at::Tensor out = at::full({resolution_1, resolution_1, resolution_1}, std::numeric_limits<float>::quiet_NaN(), at::kFloat, std::nullopt, at::kCPU, std::nullopt);
   float* out_ptr = out.data_ptr<float>();
   for (auto point : grid_points) {
     out_ptr[point.loc.x * resolution_1 * resolution_1 + point.loc.y * resolution_1 + point.loc.z] = point.value;
   }
 
-  for (int i = 1; i < resolution_1; i++) {
-    for (int j = 0; j < resolution_1; j++) {
-      for (int k = 0; k < resolution_1; k++) {
+  for (int32_t i = 1; i < resolution_1; i++) {
+    for (int32_t j = 0; j < resolution_1; j++) {
+      for (int32_t k = 0; k < resolution_1; k++) {
         if (std::isnan(out_ptr[i * resolution_1 * resolution_1 + j * resolution_1 + k]))
           out_ptr[i * resolution_1 * resolution_1 + j * resolution_1 + k] = out_ptr[(i-1) * resolution_1 * resolution_1 + j * resolution_1 + k];
       }
     }
   }
 
-  for (int i = 0; i < resolution_1; i++) {
-    for (int j = 1; j < resolution_1; j++) {
-      for (int k = 0; k < resolution_1; k++) {
+  for (int32_t i = 0; i < resolution_1; i++) {
+    for (int32_t j = 1; j < resolution_1; j++) {
+      for (int32_t k = 0; k < resolution_1; k++) {
         if (std::isnan(out_ptr[i * resolution_1 * resolution_1 + j * resolution_1 + k]))
           out_ptr[i * resolution_1 * resolution_1 + j * resolution_1 + k] = out_ptr[i * resolution_1 * resolution_1 + (j-1) * resolution_1 + k];
       }
     }
   }
 
-  for (int i = 0; i < resolution_1; i++) {
-    for (int j = 0; j < resolution_1; j++) {
-      for (int k = 1; k < resolution_1; k++) {
+  for (int32_t i = 0; i < resolution_1; i++) {
+    for (int32_t j = 0; j < resolution_1; j++) {
+      for (int32_t k = 1; k < resolution_1; k++) {
         if (std::isnan(out_ptr[i * resolution_1 * resolution_1 + j * resolution_1 + k]))
           out_ptr[i * resolution_1 * resolution_1 + j * resolution_1 + k] = out_ptr[i * resolution_1 * resolution_1 + j * resolution_1 + k - 1];
         TORCH_CHECK(!std::isnan(out_ptr[i * resolution_1 * resolution_1 + j * resolution_1 + k]));
@@ -160,7 +160,7 @@ at::Tensor MISE::to_dense() {
 void MISE::subdivide_voxels() {
   std::vector<bool> next_to_positive;
   std::vector<bool> next_to_negative;
-  long idx;
+  int64_t idx;
   Vector3D loc, adj_loc;
 
   next_to_positive.resize(voxels.size(), false);
@@ -171,9 +171,9 @@ void MISE::subdivide_voxels() {
     if (!grid_point.known)
       continue;
 
-    for (int i = -1; i < 1; i++) {
-      for (int j = -1; j < 1; j++) {
-        for (int k = -1; k < 1; k++) {
+    for (int32_t i = -1; i < 1; i++) {
+      for (int32_t j = -1; j < 1; j++) {
+        for (int32_t k = -1; k < 1; k++) {
           adj_loc = Vector3D(loc.x + i, loc.y + j, loc.z + k);
           idx = get_voxel_idx(adj_loc);
           if (idx == -1)
@@ -188,7 +188,7 @@ void MISE::subdivide_voxels() {
     }
   }
 
-  int n_subdivide = 0;
+  int32_t n_subdivide = 0;
   for (size_t idx = 0; idx < voxels.size(); idx++) {
     if (!voxels[idx].is_leaf || voxels[idx].level == depth)
       continue;
@@ -198,9 +198,9 @@ void MISE::subdivide_voxels() {
 
   voxels.reserve(voxels.size() + 8 * n_subdivide);
   grid_points.reserve(voxels.size() + 19 * n_subdivide);
-  int init_voxel_size = voxels.size();
+  int32_t init_voxel_size = voxels.size();
 
-  for (int idx = 0; idx < init_voxel_size; idx++) {
+  for (int32_t idx = 0; idx < init_voxel_size; idx++) {
     if (!voxels[idx].is_leaf || voxels[idx].level == depth)
       continue;
     if (next_to_positive[idx] && next_to_negative[idx])
@@ -208,20 +208,20 @@ void MISE::subdivide_voxels() {
   }
 }
 
-void MISE::subdivide_voxel(long idx) {
+void MISE::subdivide_voxel(int64_t idx) {
   Voxel voxel;
   GridPoint point;
   Vector3D loc0 = voxels[idx].loc;
   Vector3D loc;
-  int new_level = voxels[idx].level + 1;
-  int new_size = 1 << (depth - new_level);
+  int32_t new_level = voxels[idx].level + 1;
+  int32_t new_size = 1 << (depth - new_level);
   TORCH_CHECK(new_level <= depth);
   TORCH_CHECK(1 <= new_size && new_size <= voxel_size_0);
 
   voxels[idx].is_leaf = false;
-  for (int i = 0; i < 2; i++) {
-    for (int j = 0; j < 2; j++) {
-      for (int k = 0; k < 2; k++) {
+  for (int32_t i = 0; i < 2; i++) {
+    for (int32_t j = 0; j < 2; j++) {
+      for (int32_t k = 0; k < 2; k++) {
         loc = Vector3D(loc0.x + i * new_size, loc0.y + j * new_size, loc0.z + k * new_size);
         voxel = Voxel(loc, new_level, true);
         voxels[idx].children[i][j][k] = voxels.size();
@@ -230,9 +230,9 @@ void MISE::subdivide_voxel(long idx) {
     }
   }
   
-  for (int i = 0; i < 3; i++) {
-    for (int j = 0; j < 3; j++) {
-      for (int k = 0; k < 3; k++) {
+  for (int32_t i = 0; i < 3; i++) {
+    for (int32_t j = 0; j < 3; j++) {
+      for (int32_t k = 0; k < 3; k++) {
         loc = Vector3D(loc0.x + i * new_size, loc0.y + j * new_size, loc0.z + k * new_size);
         if (get_grid_point_idx(loc) == -1)
           add_grid_point(loc);
@@ -241,12 +241,12 @@ void MISE::subdivide_voxel(long idx) {
   }
 }
 
-long MISE::get_voxel_idx(Vector3D loc) {
+int64_t MISE::get_voxel_idx(Vector3D loc) {
   if (!(0 <= loc.x && loc.x < resolution && 0 <= loc.y && loc.y < resolution && 0 <= loc.z && loc.z < resolution))
     return -1;
 
   Vector3D loc0 = Vector3D(loc.x >> depth, loc.y >> depth, loc.z >> depth);
-  int idx = loc0.x * resolution_0 * resolution_0 + loc0.y * resolution_0 + loc0.z;
+  int32_t idx = loc0.x * resolution_0 * resolution_0 + loc0.y * resolution_0 + loc0.z;
   Voxel voxel = voxels[idx];
   TORCH_CHECK(voxel.loc.x == loc0.x * voxel_size_0);
   TORCH_CHECK(voxel.loc.y == loc0.y * voxel_size_0);
@@ -259,7 +259,7 @@ long MISE::get_voxel_idx(Vector3D loc) {
   );
 
   Vector3D loc_offset;
-  long voxel_size = voxel_size_0;
+  int64_t voxel_size = voxel_size_0;
 
   while (!voxel.is_leaf) {
     voxel_size = voxel_size >> 1;
@@ -281,18 +281,18 @@ long MISE::get_voxel_idx(Vector3D loc) {
 
 void MISE::add_grid_point(Vector3D loc) {
   GridPoint point = GridPoint(loc, 0., false);
-  int resolution_1 = resolution + 1;
+  int32_t resolution_1 = resolution + 1;
   grid_point_hash[resolution_1 * resolution_1 * loc.x + resolution_1 * loc.y + loc.z] = grid_points.size();
   grid_points.push_back(point);
 }
 
-int MISE::get_grid_point_idx(Vector3D loc) {
-  int resolution_1 = resolution + 1;
+int32_t MISE::get_grid_point_idx(Vector3D loc) {
+  int32_t resolution_1 = resolution + 1;
   auto p_idx = grid_point_hash.find(loc.x * resolution_1 * resolution_1 + loc.y * resolution_1 + loc.z);
   if (p_idx == grid_point_hash.end())
     return -1;
 
-  int idx = p_idx->second;
+  int32_t idx = p_idx->second;
   TORCH_CHECK(grid_points[idx].loc.x == loc.x);
   TORCH_CHECK(grid_points[idx].loc.y == loc.y);
   TORCH_CHECK(grid_points[idx].loc.z == loc.z);

--- a/kaolin/csrc/ops/conversions/mise/mise.h
+++ b/kaolin/csrc/ops/conversions/mise/mise.h
@@ -43,26 +43,26 @@ namespace kaolin {
 struct MISE : torch::CustomClassHolder {
 private:
   struct Vector3D {
-    int x = 0;
-    int y = 0;
-    int z = 0;
+    int32_t x = 0;
+    int32_t y = 0;
+    int32_t z = 0;
 
     Vector3D() = default;
-    Vector3D(int in_x, int in_y, int in_z) : x(in_x), y(in_y), z(in_z) {}
+    Vector3D(int32_t in_x, int32_t in_y, int32_t in_z) : x(in_x), y(in_y), z(in_z) {}
   };
 
   struct Voxel {
     Vector3D loc{};
-    unsigned int level = 0;
+    uint32_t level = 0;
     bool is_leaf = true;
-    unsigned long children[2][2][2]{};
+    uint64_t children[2][2][2]{};
 
     Voxel() = default;
-    Voxel(const Vector3D& l, unsigned int lvl, bool leaf)
+    Voxel(const Vector3D& l, uint32_t lvl, bool leaf)
         : loc(l), level(lvl), is_leaf(leaf) {
-      for (int i = 0; i < 2; i++) {
-        for (int j = 0; j < 2; j++) {
-          for (int k = 0; k < 2; k++) {
+      for (int32_t i = 0; i < 2; i++) {
+        for (int32_t j = 0; j < 2; j++) {
+          for (int32_t k = 0; k < 2; k++) {
             children[i][j][k] = 0;
           }
         }
@@ -81,18 +81,18 @@ private:
 
   std::vector<Voxel> voxels;
   std::vector<GridPoint> grid_points;
-  std::map<long, long> grid_point_hash;
-  int resolution_0;
-  int depth;
+  std::map<int64_t, int64_t> grid_point_hash;
+  int32_t resolution_0;
+  int32_t depth;
   double threshold;
-  int voxel_size_0;
-  int resolution;
+  int32_t voxel_size_0;
+  int32_t resolution;
 
   void subdivide_voxels();
-  void subdivide_voxel(long idx);
-  long get_voxel_idx(Vector3D loc);
+  void subdivide_voxel(int64_t idx);
+  int64_t get_voxel_idx(Vector3D loc);
   void add_grid_point(Vector3D loc);
-  int get_grid_point_idx(Vector3D loc);
+  int32_t get_grid_point_idx(Vector3D loc);
 
 public:
   MISE(int32_t in_resolution_0, int32_t in_depth, double in_threshold);

--- a/kaolin/csrc/ops/spc/bf_cuda.cu
+++ b/kaolin/csrc/ops/spc/bf_cuda.cu
@@ -17,7 +17,6 @@
 #define CUB_NS_POSTFIX }
 #define CUB_NS_QUALIFIER ::kaolin::cub
 
-#include <torch/extension.h>
 #include <stdio.h>
 
 #include <math_constants.h>

--- a/kaolin/csrc/ops/spc/recon_cuda.cu
+++ b/kaolin/csrc/ops/spc/recon_cuda.cu
@@ -17,7 +17,6 @@
 #define CUB_NS_POSTFIX }
 #define CUB_NS_QUALIFIER ::kaolin::cub
 
-#include <torch/extension.h>
 #include <stdio.h>
 #include <math_constants.h>
 

--- a/kaolin/render/easy_render/mesh.py
+++ b/kaolin/render/easy_render/mesh.py
@@ -201,7 +201,7 @@ def mesh_rasterize_interpolate_nvdiffrast(
 
         Args:
             mesh (SurfaceMesh): unbatched surface mesh
-            nvdiffrast_context (render context): nvdiffrast context, either CUDA or OpenGL
+            nvdiffrast_context (render context): nvdiffrast context (CUDA)
             camera (Camera): single camera
             normals_required (bool): if True, will compute interpolated mesh normals, else return None
             uvs_required (bool): if True, and present in mesh, will compute interpolated mesh uvs, else return None

--- a/kaolin/render/mesh/nvdiffrast_context.py
+++ b/kaolin/render/mesh/nvdiffrast_context.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,12 +20,10 @@ logger = logging.getLogger(__name__)
 
 _device2glctx = {}
 _has_nvdiffrast = False
-_default_context_fn = lambda device: None
 
 try:
     import nvdiffrast.torch as nvdiff
     _has_nvdiffrast = True
-    _default_context_fn = partial(nvdiff.RasterizeCudaContext)
 except ImportError:
     nvdiff = None
     logger.info("Cannot import nvdiffrast")
@@ -40,61 +38,14 @@ def nvdiffrast_is_available():
     return _has_nvdiffrast
 
 
-def nvdiffrast_use_cuda():
-    """ Configures nvdiffrast back end to use `nvdiffrast.torch.RasterizeCudaContext` by default.
-
-    This reset the cached nvdiffrast contexts.
-
-    .. note::
-        nvdiffrast only support a resolution multiple of 8.
-    """
-    global _default_context_fn
-    if nvdiffrast_is_available():
-        _default_context_fn = nvdiff.RasterizeCudaContext
-        _device2glctx.clear()
-    else:
-        _log_not_available()
-
-
-def nvdiffrast_use_opengl():
-    """ Configures nvdiffrast back end to use `nvdiffrast.torch.RasterizeGLContext` by default.
-
-
-    This reset the cached nvdiffrast contexts.
-    """
-    global _default_context_fn
-    if nvdiffrast_is_available():
-        _default_context_fn = partial(nvdiff.RasterizeGLContext, output_db=False)
-        _device2glctx.clear()
-    else:
-        _log_not_available()
-
-
-def set_default_nvdiffrast_context(context, device="cuda"):
-    """ Allows manually setting default nvdiffrast context to the given value for a specific device.
-
-    Args:
-        context (nvdiffrast.torch.RasterizeCudaContext or nvdiffrast.torch.RasterizeGLContext): context instance
-        device (str, torch.device): pytorch device
-    """
-    if nvdiffrast_is_available():
-        device_name = str(device)
-        if device_name in _device2glctx:
-            logger.warning(f'Replacing default nvdiffrast context for device {device_name}.')
-        _device2glctx[device_name] = context
-    else:
-        _log_not_available()
-
-
 def default_nvdiffrast_context(device, raise_error=False):
-    """ Returns existing context for device, or creates one. To configure nvdiffrast to use opengl or CUDA back
-    end by default call :func:`nvdiffrast_use_cuda` or func:`nvdiffrast_use_opengl`.
+    """Returns existing context for device, or creates one.
 
     Args:
         device (str or torch.device): device for the context
 
     Returns:
-        nvdiffrast.torch.RasterizeCudaContext or nvdiffrast.torch.RasterizeGLContext
+        nvdiffrast.torch.RasterizeCudaContext
     """
     if not nvdiffrast_is_available():
         if raise_error:
@@ -104,6 +55,6 @@ def default_nvdiffrast_context(device, raise_error=False):
 
     device_name = str(device)
     if device_name not in _device2glctx:
-        _device2glctx[device_name] = _default_context_fn(device=device)
+        _device2glctx[device_name] = nvdiff.RasterizeCudaContext(device=device)
     return _device2glctx[device_name]
 

--- a/kaolin/render/mesh/rasterization.py
+++ b/kaolin/render/mesh/rasterization.py
@@ -388,9 +388,7 @@ def rasterize(height,
     `Learning to Predict 3D Objects with an Interpolation-based Differentiable Renderer`_ NeurIPS 2019.
 
     .. note::
-       `nvdiffrast library`_ is relying on OpenGL or a custom CUDA depending on selected context
-       (see :ref:`nvdiffrast context <kaolin.render.mesh.nvdiffrast_context>`) 
-       and is usually faster especially on larger mesh and resolution.
+       `nvdiffrast library`_ is relying on a custom CUDA context and is usually faster especially on larger meshes and resolution.
 
     Args:
         height (int):

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,8 @@ import sys
 import subprocess  # Added import
 
 # Define version constraints
-TORCH_MIN_VER = '1.6.0'
-TORCH_MAX_VER = '2.8.0'  # Updated to support newer PyTorch versions
-CYTHON_MIN_VER = '0.29.37'
+TORCH_MIN_VER = '2.3.0'
+TORCH_MAX_VER = '2.10.0'  # Updated to support newer PyTorch versions
 IGNORE_TORCH_VER = os.getenv('IGNORE_TORCH_VER') is not None
 
 # Module required before installation
@@ -73,9 +72,7 @@ def get_cuda_bare_metal_version(cuda_dir):
 # Handle CUDA availability
 if not torch.cuda.is_available() and os.getenv('FORCE_CUDA', '0') == '1':
     logging.warning(
-        "Torch did not find available GPUs. Assuming cross-compilation.\n"
-        "Default architectures: Pascal (6.0, 6.1, 6.2), Volta (7.0), Turing (7.5),\n"
-        "Ampere (8.0) if CUDA >= 11.0, Hopper (9.0) if CUDA >= 11.8, Blackwell (12.0) if CUDA >= 12.8\n"
+        "Torch did not find available GPUs. Assuming cross-compilation and all supported architectures.\n"
         "Set TORCH_CUDA_ARCH_LIST for specific architectures."
     )
     if os.getenv("TORCH_CUDA_ARCH_LIST") is None:
@@ -91,10 +88,15 @@ if not torch.cuda.is_available() and os.getenv('FORCE_CUDA', '0') == '1':
         elif major == 12:
             if minor <= 6:
                 os.environ["TORCH_CUDA_ARCH_LIST"] = "6.0;6.1;6.2;7.0;7.5;8.0;8.6;9.0"
-            else:
+            elif minor == 8:
                 os.environ["TORCH_CUDA_ARCH_LIST"] = "6.0;6.1;6.2;7.0;7.5;8.0;8.6;9.0;12.0"
+            else:
+                os.environ["TORCH_CUDA_ARCH_LIST"] = "6.0;6.1;6.2;7.0;7.5;8.0;8.6;9.0;12.0;12.1"
+        elif major == 13:
+            os.environ["TORCH_CUDA_ARCH_LIST"] = "7.5;8.0;8.6;8.9;9.0;12.0;12.1"
         else:
             os.environ["TORCH_CUDA_ARCH_LIST"] = "6.0;6.1;6.2;7.0;7.5"
+
         print(f'TORCH_CUDA_ARCH_LIST: {os.environ["TORCH_CUDA_ARCH_LIST"]}')
 elif not torch.cuda.is_available():
     logging.warning(

--- a/tests/python/kaolin/render/camera/test_gsplats.py
+++ b/tests/python/kaolin/render/camera/test_gsplats.py
@@ -49,11 +49,11 @@ def gs_cam_cls():
 
     sys.path.append(LOCAL_GSPLATS_DIR)
     subprocess.check_call([
-        sys.executable, "-m", "pip", "install",
+        sys.executable, "-m", "pip", "install", "--no-build-isolation",
         os.path.join(LOCAL_GSPLATS_DIR, "submodules", "diff-gaussian-rasterization")
     ])
     subprocess.check_call([
-        sys.executable, "-m", "pip", "install",
+        sys.executable, "-m", "pip", "install", "--no-build-isolation",
         os.path.join(LOCAL_GSPLATS_DIR, "submodules", "simple-knn")
     ])
     from scene.cameras import Camera as GSCamera

--- a/tests/python/kaolin/render/mesh/test_nvdiffrast_context.py
+++ b/tests/python/kaolin/render/mesh/test_nvdiffrast_context.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,9 +17,6 @@ import os
 import torch
 import pytest
 
-from importlib import reload
-
-global kaolin
 import kaolin
 
 if os.getenv('KAOLIN_TEST_NVDIFFRAST', '0') == '0':
@@ -29,38 +26,7 @@ class TestNvidiaContext:
 
     @pytest.mark.parametrize('device', ['cuda:0', 'cuda'])
     @pytest.mark.parametrize('raise_error', [True, False])
-    def test_true_default_nvdiffrast_context(self, device, raise_error):
+    def test_default_nvdiffrast_context(self, device, raise_error):
         import nvdiffrast.torch
-        global kaolin
-        kaolin = reload(kaolin)
         ctx = kaolin.render.mesh.nvdiffrast_context.default_nvdiffrast_context(device, raise_error)
         assert isinstance(ctx, nvdiffrast.torch.RasterizeCudaContext)
-        # TODO(cfujitsang): is there a way to test for specific device?
-
-    @pytest.mark.skipif(os.getenv('KAOLIN_TEST_NVDIFFRAST_OPENGL', '0') == '0', reason='test is ignored as KAOLIN_TEST_NVDIFFRAST_OPENGL is not set')
-    @pytest.mark.parametrize('device', ['cuda:0', 'cuda'])
-    @pytest.mark.parametrize('raise_error', [True, False])
-    def test_cuda_default_nvdiffrast_context(self, device, raise_error):
-        import nvdiffrast.torch
-        global kaolin
-        kaolin = reload(kaolin)
-        kaolin.render.mesh.nvdiffrast_context.nvdiffrast_use_opengl()
-        ctx = kaolin.render.mesh.nvdiffrast_context.default_nvdiffrast_context(device, raise_error)
-        assert isinstance(ctx, nvdiffrast.torch.RasterizeGLContext)
-        kaolin.render.mesh.nvdiffrast_context.nvdiffrast_use_cuda()
-        ctx = kaolin.render.mesh.nvdiffrast_context.default_nvdiffrast_context(device, raise_error)
-        assert isinstance(ctx, nvdiffrast.torch.RasterizeCudaContext)
-
-    @pytest.mark.skipif(os.getenv('KAOLIN_TEST_NVDIFFRAST_OPENGL', '0') == '0', reason='test is ignored as KAOLIN_TEST_NVDIFFRAST_OPENGL is not set')
-    @pytest.mark.parametrize('device', ['cuda:0', 'cuda'])
-    @pytest.mark.parametrize('raise_error', [True, False])
-    def test_opengl_default_nvdiffrast_context(self, device, raise_error):
-        import nvdiffrast.torch
-        global kaolin
-        kaolin = reload(kaolin)
-        kaolin.render.mesh.nvdiffrast_context.nvdiffrast_use_cuda()
-        ctx = kaolin.render.mesh.nvdiffrast_context.default_nvdiffrast_context(device, raise_error)
-        assert isinstance(ctx, nvdiffrast.torch.RasterizeCudaContext)
-        kaolin.render.mesh.nvdiffrast_context.nvdiffrast_use_opengl()
-        ctx = kaolin.render.mesh.nvdiffrast_context.default_nvdiffrast_context(device, raise_error)
-        assert isinstance(ctx, nvdiffrast.torch.RasterizeGLContext)

--- a/tools/get_nvdiffrast_compatible_arch.py
+++ b/tools/get_nvdiffrast_compatible_arch.py
@@ -1,0 +1,37 @@
+import subprocess
+
+from torch.utils.cpp_extension import CUDA_HOME
+
+def get_cuda_bare_metal_version(cuda_dir):
+    """Get CUDA version from nvcc."""
+    raw_output = subprocess.check_output([cuda_dir + "/bin/nvcc", "-V"], universal_newlines=True)
+    output = raw_output.split()
+    release_idx = output.index("release") + 1
+    release = output[release_idx].split(".")
+    return raw_output, release[0], release[1][0]
+
+if __name__ == "__main__":
+    if CUDA_HOME is None:
+        raise RuntimeError("Pytorch doesn't have CUDA_HOME set.")
+    _, major, minor = get_cuda_bare_metal_version(CUDA_HOME)
+    major, minor = int(major), int(minor)
+    if major == 11:
+        if minor == 0:
+            arch_list = "6.0;6.1;6.2;7.0;7.5;8.0"
+        elif minor < 8:
+            arch_list = "6.0;6.1;6.2;7.0;7.5;8.0;8.6"
+        else:
+            arch_list = "6.0;6.1;6.2;7.0;7.5;8.0;8.6;8.9"
+    elif major == 12:
+        if minor <= 6:
+            arch_list = "6.0;6.1;6.2;7.0;7.5;8.0;8.6;9.0"
+        elif minor == 8:
+            arch_list = "6.0;6.1;6.2;7.0;7.5;8.0;8.6;9.0;12.0"
+        else:
+            arch_list = "6.0;6.1;6.2;7.0;7.5;8.0;8.6;9.0;12.0;12.1"
+    elif major == 13:
+        arch_list = "7.5;8.0;8.6;8.9;9.0;12.0;12.1"
+    else:
+        arch_list = "6.0;6.1;6.2;7.0;7.5"
+    print(arch_list)
+

--- a/tools/linux/Dockerfile.install
+++ b/tools/linux/Dockerfile.install
@@ -15,40 +15,29 @@ RUN if [ -f /etc/apt/sources.list.d/cuda.list ]; then \
         rm /etc/apt/sources.list.d/nvidia-ml.list; \
     fi
 
-WORKDIR /kaolin
-
-COPY . .
-
 RUN echo "Acquire { https::Verify-Peer false }" > /etc/apt/apt.conf.d/99verify-peer.conf \
     && apt-get -y update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated ca-certificates \
     && rm /etc/apt/apt.conf.d/99verify-peer.conf \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        libgl1-mesa-dev \
-        libgles2-mesa-dev \
-        libegl1-mesa-dev \
         git \
         pkg-config \
-	libatk1.0-0 \
-	libatk-bridge2.0-0 \
-	libasound2 \
+        libatk1.0-0 \
+        libatk-bridge2.0-0 \
         libgtk2.0-0 \
         libgtk-3-0 \
-	libnss3 \
-        libglvnd0 \
-        libgl1 \
-        libglx0 \
-        libegl1 \
-        libgles2 \
-        libglvnd-dev \
-	curl \
+        libnss3 \   
+        curl \
         cmake \
         xvfb \
-	wget \
-	software-properties-common \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+        wget \
+        software-properties-common \
+        && (apt-get install -y --no-install-recommends libasound2 || apt-get install -y --no-install-recommends libasound2t64) \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
 
+# Remove PEP 668 restriction (safe in containers)
+RUN rm -f /usr/lib/python*/EXTERNALLY-MANAGED
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -56,32 +45,33 @@ ENV PYTHONUNBUFFERED=1
 # fix for a weird pytorch bug (see: https://discuss.pytorch.org/t/not-able-to-include-cusolverdn-h/169122/5)
 ENV PATH /usr/local/cuda/bin:$PATH
 
-# for GLEW
-ENV LD_LIBRARY_PATH /usr/lib64:/usr/local/cuda/lib64:/usr/local/cuda/lib:${LD_LIBRARY_PATH}
+WORKDIR /kaolin
 
-# nvidia-container-runtime
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility,graphics
+COPY . .
 
-## Install Dash3D Requirements ###
+# Install Dash3D Requirements ###
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x --insecure | bash - \
     && apt-get install -y nodejs
 
 RUN npm install -g npm@8.5.4
 RUN npm install 
 
-RUN pip install --upgrade pip && \
-    pip install --no-cache-dir ninja \
-        imageio imageio-ffmpeg && \
-    pip install --no-cache-dir \
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir \
+       	ninja \
+        imageio \
+	imageio-ffmpeg
+RUN pip install --ignore-installed --no-cache-dir \
         -r tools/viz_requirements.txt \
         -r tools/requirements.txt \
         -r tools/build_requirements.txt
 
-#RUN cd /tmp && \
-#    git clone https://github.com/NVlabs/nvdiffrast && \
-#    cd nvdiffrast && \
-#    cp ./docker/10_nvidia.json /usr/share/glvnd/egl_vendor.d/10_nvidia.json && \
-#    pip install .
+RUN if [ "$FORCE_CUDA" -eq "1" ]; then \
+    export TORCH_CUDA_ARCH_LIST=`python tools/get_nvdiffrast_compatible_arch.py` && \
+    cd /tmp && \
+    git clone https://github.com/NVlabs/nvdiffrast && \
+    cd nvdiffrast && \
+    export MAX_JOBS=1 && \
+    pip install --no-build-isolation --break-system-packages .; fi
 
 RUN export MAX_JOBS=1 && python setup.py develop

--- a/tools/linux/Dockerfile.install_wheel
+++ b/tools/linux/Dockerfile.install_wheel
@@ -19,30 +19,23 @@ COPY ./tests ./tests
 COPY ./tools ./tools
 RUN apt-get -y update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        libgl1-mesa-dev \
-        libgles2-mesa-dev \
-        libegl1-mesa-dev \
         git \
         pkg-config \
         libatk1.0-0 \
         libatk-bridge2.0-0 \
-        libasound2 \
         libgtk2.0-0 \
         libgtk-3-0 \
         libnss3 \
-        libglvnd0 \
-        libgl1 \
-        libglx0 \
-        libegl1 \
-        libgles2 \
-        libglvnd-dev \
         curl \
         cmake \
         xvfb \
         wget \
+    && (apt-get install -y --no-install-recommends libasound2 || apt-get install -y --no-install-recommends libasound2t64) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Remove PEP 668 restriction (safe in containers)
+RUN rm -f /usr/lib/python*/EXTERNALLY-MANAGED
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -66,10 +59,14 @@ RUN npm install
 
 RUN pip install --upgrade pip && pip install ninja
 
-RUN cd /tmp && \
+RUN if [ "$FORCE_CUDA" -eq "1" ]; then \
+    export TORCH_CUDA_ARCH_LIST=`python ./tools/get_nvdiffrast_compatible_arch.py` && \
+    /tmp && \
     git clone https://github.com/NVlabs/nvdiffrast && \
     cd nvdiffrast && \
-    cp ./docker/10_nvidia.json /usr/share/glvnd/egl_vendor.d/10_nvidia.json && \
-    pip install .
+    export MAX_JOBS=1 && \
+    pip install --no-build-isolation --break-system-packages .; fi
+
+
 
 RUN pip install ./${WHEEL_NAME}

--- a/tools/windows/Dockerfile.base
+++ b/tools/windows/Dockerfile.base
@@ -1,37 +1,43 @@
-# Note: Keep C:\Program Files (x86)\Microsoft Visual Studio\Installer directory.
-#       disutils/setuptools calls vswhere.exe from that location unconditionally.
-
-ARG BASE_IMAGE="mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
+ARG BASE_IMAGE="mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022"
 FROM ${BASE_IMAGE}
 
 # set up conda and python environment
 ARG CUDA_VERSION=11.1
 ENV CUDA_VERSION=${CUDA_VERSION}
-ARG PYTHON_VERSION=3.7
-ENV PYTHON_VERSION=${PYTHON_VERSION}
-ARG PYTORCH_VERSION=1.8
-ENV PYTORCH_VERSION=${PYTORCH_VERSION}
-ARG FORCE_CUDA=1
-ENV FORCE_CUDA=${FORCE_CUDA}
-
 ARG CUDA_URL="http://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_456.81_win10.exe"
 ENV CUDA_URL=${CUDA_URL}
 ARG CUDA_FILENAME=cuda_${CUDA_VERSION}_win10.exe
 ENV CUDA_FILENAME=${CUDA_FILENAME}
 
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 #### BUILD TOOLS ####
 
 # pulling downloads to top to not repeat
-# download & install VS build tools 2019
-RUN Invoke-WebRequest "https://aka.ms/vs/16/release/vs_buildtools.exe" -OutFile vs_buildtools.exe -UseBasicParsing; \
-    Start-Process -FilePath 'vs_buildtools.exe' -Wait -ArgumentList '--quiet', '--norestart', '--downloadThenInstall', '--nocache', '--wait', '--installPath', 'C:\BuildTools', '--add', 'Microsoft.VisualStudio.Workload.VCTools'; \
-    Start-Process -FilePath 'vs_buildtools.exe' -Wait -ArgumentList '--quiet', '--norestart', '--downloadThenInstall', '--nocache', '--wait', '--installPath', 'C:\BuildTools', '--add', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'; \
-    Start-Process -FilePath 'vs_buildtools.exe' -Wait -ArgumentList '--quiet', '--norestart', '--downloadThenInstall', '--nocache', '--wait', '--installPath', 'C:\BuildTools', '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools'; \
-    Start-Process -FilePath 'vs_buildtools.exe' -Wait -ArgumentList '--quiet', '--norestart', '--downloadThenInstall', '--nocache', '--wait', '--installPath', 'C:\BuildTools', '--add', 'Microsoft.Component.VC.Runtime.UCRTSDK'; \
-    Start-Process -FilePath 'vs_buildtools.exe' -Wait -ArgumentList '--quiet', '--norestart', '--downloadThenInstall', '--nocache', '--wait', '--installPath', 'C:\BuildTools', '--add', 'Microsoft.VisualStudio.Component.Windows10SDK.18362'; \
-    Remove-Item .\vs_buildtools.exe
+# download & install VS build tools 17.x (Visual Studio 2022)
+RUN Invoke-WebRequest 'https://aka.ms/vs/17/release/vs_buildtools.exe' -OutFile vs_buildtools.exe -UseBasicParsing; \
+    $components = @( \
+        'Microsoft.VisualStudio.Workload.VCTools', \
+        'Microsoft.VisualStudio.Component.VC.Tools.x86.x64', \
+        'Microsoft.VisualStudio.Component.VC.14.34.17.4.x86.x64', \
+        'Microsoft.VisualStudio.Workload.MSBuildTools', \
+        'Microsoft.Component.VC.Runtime.UCRTSDK', \
+        'Microsoft.VisualStudio.Component.Windows10SDK.17763' \
+    ); \
+    $args = @('--quiet', '--norestart', '--downloadThenInstall', '--nocache', '--wait', '--installPath', 'C:\BuildTools'); \
+    foreach ($c in $components) { $args += '--add'; $args += $c }; \
+    $p = Start-Process -FilePath 'vs_buildtools.exe' -Wait -PassThru -ArgumentList $args; \
+    if ($p.ExitCode -ne 0 -and $p.ExitCode -ne 3010) { throw ('Install failed: ' + $p.ExitCode) }; \
+    Remove-Item .\vs_buildtools.exe; \
+    Get-ChildItem -Path 'C:\Program Files (x86)\Windows Kits\10' -Recurse -Filter 'basetsd.h' | Select-Object -ExpandProperty FullName
 
+RUN New-Item -ItemType Directory -Path 'C:\TEMP' -Force; \
+    Invoke-WebRequest -Uri 'https://go.microsoft.com/fwlink/?linkid=2120843' -OutFile 'C:\TEMP\winsdksetup.exe' -UseBasicParsing; \
+    $p = Start-Process -FilePath 'C:\TEMP\winsdksetup.exe' -ArgumentList '/features', '+', '/quiet', '/norestart' -Wait -PassThru; \
+    Write-Host ('SDK installer exit code: ' + $p.ExitCode); \
+    if ($p.ExitCode -ne 0 -and $p.ExitCode -ne 3010) { throw ('SDK install failed: ' + $p.ExitCode) }; \
+    Remove-Item 'C:\TEMP\winsdksetup.exe' -Force; \
+    Get-ChildItem -Path 'C:\Program Files (x86)\Windows Kits\10' -Recurse -Filter 'basetsd.h' | Select-Object -ExpandProperty FullName
 
 # The msvc version (subdir) has been shown to change over time.
 # The winsdk version (subdir) may change over time either through changes by MS or our own arguments to vs_buildtools.exe above.
@@ -42,6 +48,28 @@ RUN setx /M PATH $('c:\buildtools\vc\tools\msvc\' + $(Get-ChildItem -Path 'c:\bu
     + 'C:\Program Files (x86)\Windows Kits\10\bin\' + $(Get-ChildItem -Path 'C:\Program Files (x86)\Windows Kits\10\bin\' -Force -Directory | Select-Object -First 1).Name + '\x64;' \
     + 'C:\BuildTools\VC\Auxiliary\Build;' \
     + $Env:PATH)
+
+RUN Get-ChildItem -Path 'c:\buildtools\vc\tools\msvc\' -Directory | Select-Object -ExpandProperty Name
+
+RUN $msvcDir = $(Get-ChildItem -Path 'c:\buildtools\vc\tools\msvc\' -Force -Directory | Where-Object { $_.Name -like '14.34*' } | Select-Object -First 1).FullName; \
+    $sdkVersion = $(Get-ChildItem -Path 'C:\Program Files (x86)\Windows Kits\10\Include\' -Force -Directory | Sort-Object -Descending | Select-Object -First 1).Name; \
+    $sdkBinBase = 'C:\Program Files (x86)\Windows Kits\10\bin\' + $sdkVersion; \
+    $sdkIncBase = 'C:\Program Files (x86)\Windows Kits\10\Include\' + $sdkVersion; \
+    $sdkLibBase = 'C:\Program Files (x86)\Windows Kits\10\Lib\' + $sdkVersion; \
+    $pathValue = $msvcDir + '\bin\hostx64\x64;' + $msvcDir + '\lib\x64;' + $msvcDir + '\include;' + $sdkBinBase + '\x64;C:\BuildTools\VC\Auxiliary\Build;' + $Env:PATH; \
+    $incValue = $msvcDir + '\include;' + $sdkIncBase + '\ucrt;' + $sdkIncBase + '\shared;' + $sdkIncBase + '\um;' + $sdkIncBase + '\winrt'; \
+    $libValue = $msvcDir + '\lib\x64;' + $sdkLibBase + '\ucrt\x64;' + $sdkLibBase + '\um\x64'; \
+    Write-Host ('MSVC: ' + $msvcDir); \
+    Write-Host ('SDK: ' + $sdkVersion); \
+    [Environment]::SetEnvironmentVariable('PATH', $pathValue, 'Machine'); \
+    [Environment]::SetEnvironmentVariable('INCLUDE', $incValue, 'Machine'); \
+    [Environment]::SetEnvironmentVariable('LIB', $libValue, 'Machine')
+
+RUN $clPath = $(Get-ChildItem -Path 'c:\buildtools\vc\tools\msvc\' -Force -Directory | Where-Object { $_.Name -like '14.34*' } | Select-Object -First 1).FullName + '\bin\hostx64\x64\cl.exe'; \
+    Write-Host ('CUDAHOSTCXX=' + $clPath); \
+    [Environment]::SetEnvironmentVariable('CUDAHOSTCXX', $clPath, 'Machine'); \
+    [Environment]::SetEnvironmentVariable('VCToolsVersion', '14.34.31933', 'Machine')
+
 
 #### CUDA ####
 
@@ -62,9 +90,31 @@ RUN setx /M PATH $('c:\buildtools\vc\tools\msvc\' + $(Get-ChildItem -Path 'c:\bu
 # TODO: may need to add more packages or alter names for later CUDA versions...
 # CUDA 11.3+ adds 'thrust' to the set of requirements we need to install
 RUN Invoke-WebRequest $Env:CUDA_URL -OutFile $Env:CUDA_FILENAME -UseBasicParsing; \
-    if ([convert]::ToDouble(${Env:CUDA_VERSION}) -ge 11.3) { Start-Process -FilePath \"$Env:CUDA_FILENAME\" -Wait -ArgumentList '-s', \"nvcc_${Env:CUDA_VERSION}\", \"cusparse_${Env:CUDA_VERSION}\", \"cusparse_dev_${Env:CUDA_VERSION}\", \"cublas_${Env:CUDA_VERSION}\", \"cublas_dev_${Env:CUDA_VERSION}\", \"curand_${Env:CUDA_VERSION}\", \"curand_dev_${Env:CUDA_VERSION}\", \"cudart_${Env:CUDA_VERSION}\", \"cusolver_${Env:CUDA_VERSION}\", \"cusolver_dev_${Env:CUDA_VERSION}\", \"thrust_${Env:CUDA_VERSION}\" } \
-    else { Start-Process -FilePath \"$Env:CUDA_FILENAME\" -Wait -ArgumentList '-s', \"nvcc_${Env:CUDA_VERSION}\", \"cusparse_${Env:CUDA_VERSION}\", \"cusparse_dev_${Env:CUDA_VERSION}\", \"cublas_${Env:CUDA_VERSION}\", \"cublas_dev_${Env:CUDA_VERSION}\", \"curand_${Env:CUDA_VERSION}\", \"curand_dev_${Env:CUDA_VERSION}\", \"cudart_${Env:CUDA_VERSION}\", \"cusolver_${Env:CUDA_VERSION}\", \"cusolver_dev_${Env:CUDA_VERSION}\"; } \
-    Remove-Item $Env:CUDA_FILENAME
+    Write-Host '=== Try 1: no version suffix ==='; \
+    $components1 = @( \
+        'cuda_nvcc', 'cuda_cudart', 'cuda_crt', 'cuda_cccl', \
+        'cuda_nvtx', 'cuda_nvrtc', 'cuda_profiler_api', \
+        'libcublas', 'libcusparse', 'libcurand', 'libcusolver', \
+        'visual_studio_integration' \
+    ); \
+    $p1 = Start-Process -FilePath $Env:CUDA_FILENAME -Wait -PassThru -ArgumentList (@('-s') + $components1); \
+    Write-Host ('Exit code (no suffix): ' + $p1.ExitCode); \
+    if ($p1.ExitCode -ne 0) { \
+        Write-Host '=== Try 2: _13.0.2 suffix ==='; \
+        $components2 = $components1 | ForEach-Object { $_ + '_13.0.2' }; \
+        Write-Host ($components2 -join ', '); \
+        $p2 = Start-Process -FilePath $Env:CUDA_FILENAME -Wait -PassThru -ArgumentList (@('-s') + $components2); \
+        Write-Host ('Exit code (13.0.2): ' + $p2.ExitCode); \
+        if ($p2.ExitCode -ne 0) { \
+            Write-Host '=== Try 3: just install everything ==='; \
+            $p3 = Start-Process -FilePath $Env:CUDA_FILENAME -Wait -PassThru -ArgumentList '-s'; \
+            Write-Host ('Exit code (full install): ' + $p3.ExitCode); \
+            if ($p3.ExitCode -ne 0) { throw ('All CUDA install attempts failed. Last: ' + $p3.ExitCode) }; \
+        }; \
+    }; \
+    Remove-Item $Env:CUDA_FILENAME; \
+    Write-Host '=== Verify crt/host_config.h ==='; \
+    Get-ChildItem -Path 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA' -Recurse -Filter 'host_config.h' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName
 
 # TODO: can we use conda cuda install instead? only once we need cuda 11.3.0+
 # RUN conda install -y cuda cuda-nvcc -c nvidia/label/cuda-11.3.1
@@ -82,11 +132,3 @@ RUN Start-Process -FilePath 'miniconda3.exe' -Wait -ArgumentList '/S', '/D=C:\Us
     conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main; \
     conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r; \
     conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/msys2; \
-    conda install -y python=$Env:PYTHON_VERSION
-
-# NOTE: update the install list (2 lines here) if SSL_CERTIFICATE errors crop up to pip install the related dependency
-RUN $Env:TORCH_STR = ${Env:PYTORCH_VERSION} + '+cu' + ${Env:CUDA_VERSION}.Replace('.',''); \
-    $Env:TORCH_URL='https://download.pytorch.org/whl/cu' + ${Env:CUDA_VERSION}.Replace('.',''); \
-    pip install --no-cache-dir torch==${Env:TORCH_STR} torchvision --index-url ${Env:TORCH_URL};
-
-RUN pip install brotli

--- a/tools/windows/Dockerfile.install
+++ b/tools/windows/Dockerfile.install
@@ -1,17 +1,38 @@
 # Note: Keep C:\Program Files (x86)\Microsoft Visual Studio\Installer directory.
 #       disutils/setuptools calls vswhere.exe from that location unconditionally.
-
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG PYTHON_VERSION=3.9
+ARG PYTORCH_VERSION=2.3.0
+ARG FORCE_CUDA=1
 ARG IGNORE_TORCH_VER=0
+
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+ENV PYTORCH_VERSION=${PYTORCH_VERSION}
+ENV FORCE_CUDA=${FORCE_CUDA}
 ENV IGNORE_TORCH_VER=${IGNORE_TORCH_VER}
 
-#### Kaolin ####
 
-WORKDIR /kaolin
+RUN conda install -y python=$Env:PYTHON_VERSION
+
+# NOTE: update the install list (2 lines here) if SSL_CERTIFICATE errors crop up to pip install the related dependency
+RUN $cudaDir = Get-ChildItem -Path 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\' -Directory | Select-Object -First 1 -ExpandProperty Name; \
+    if (-not $cudaDir) { throw 'No CUDA installation found' }; \
+    $cudaVer = $cudaDir.TrimStart('v'); \
+    Write-Host ('Detected CUDA: ' + $cudaVer); \
+    $Env:TORCH_STR = ${Env:PYTORCH_VERSION} + '+cu' + $cudaVer.Replace('.',''); \
+    $Env:TORCH_URL='https://download.pytorch.org/whl/cu' + $cudaVer.Replace('.',''); \
+    Write-Host ('Installing PyTorch: torch==' + ${Env:TORCH_STR} + ' from ' + ${Env:TORCH_URL}); \
+    pip install --no-cache-dir torch==${Env:TORCH_STR} torchvision --index-url ${Env:TORCH_URL};
+
+
+RUN pip install brotli
+
 
 RUN conda list > conda_build.txt
+
+WORKDIR /kaolin
 
 COPY . .
 
@@ -21,7 +42,11 @@ RUN pip install --no-cache-dir --trusted-host pypi.org --trusted-host pypi.pytho
     --trusted-host files.pythonhosted.org -r tools\ci_requirements.txt \
     -r tools\viz_requirements.txt -r tools\requirements.txt -r tools/build_requirements.txt
 
-RUN python setup.py develop
+SHELL ["cmd", "/S", "/C"]
+
+RUN "C:\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.34 && \
+    set DISTUTILS_USE_SDK=1 && \
+    python setup.py develop
 
 # fix for paging memory issue on CI machines
 #   see: https://gist.github.com/cobryan05/7d1fe28dd370e110a372c4d268dcb2e5

--- a/tools/windows/Dockerfile.install_wheel
+++ b/tools/windows/Dockerfile.install_wheel
@@ -4,8 +4,32 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG PYTHON_VERSION=3.7
+ARG PYTORCH_VERSION=1.8
+ARG FORCE_CUDA=1
 ARG IGNORE_TORCH_VER=0
+
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+ENV PYTORCH_VERSION=${PYTORCH_VERSION}
+ENV FORCE_CUDA=${FORCE_CUDA}
 ENV IGNORE_TORCH_VER=${IGNORE_TORCH_VER}
+
+RUN Write-Host $Env:PYTHON_VERSION
+
+RUN conda install -y python=$Env:PYTHON_VERSION
+
+RUN $cudaDir = Get-ChildItem -Path 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\' -Directory | Select-Object -First 1 -ExpandProperty Name; \
+    $cudaVer = $cudaDir.TrimStart('v'); \
+    Write-Host ('Detected CUDA: ' + $cudaVer); \
+    [Environment]::SetEnvironmentVariable('CUDA_VERSION', $cudaVer, 'Machine')
+
+RUN $Env:TORCH_STR = ${Env:PYTORCH_VERSION} + '+cu' + ${Env:CUDA_VERSION}.Replace('.',''); \
+    $Env:TORCH_URL='https://download.pytorch.org/whl/cu' + ${Env:CUDA_VERSION}.Replace('.',''); \
+    pip install --no-cache-dir torch==${Env:TORCH_STR} torchvision --index-url ${Env:TORCH_URL};
+
+RUN pip install brotli
+
+RUN conda list > conda_build.txt
 
 WORKDIR /kaolin
 
@@ -16,5 +40,11 @@ RUN pip install --upgrade --no-cache-dir certifi ninja
 RUN pip install --no-cache-dir --trusted-host pypi.org --trusted-host pypi.python.org \
     --trusted-host files.pythonhosted.org -r tools/build_requirements.txt
 
-RUN python setup.py bdist_wheel --dist-dir .
-RUN Get-ChildItem "./" -Filter "*.whl" | Foreach-Object {$filepath=$_.FullName; pip install $filepath}
+SHELL ["cmd", "/S", "/C"]
+
+RUN "C:\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.34 && \
+    set DISTUTILS_USE_SDK=1 && \
+    set FORCE_CUDA=1 && \
+    set CUDAHOSTCXX=c:\buildtools\vc\tools\msvc\14.34.31933\bin\hostx64\x64\cl.exe && \
+    python setup.py bdist_wheel --dist-dir . && \
+    for %f in (kaolin-*.whl) do pip install %f


### PR DESCRIPTION
There are multiple parts to this MRs but the end goal is to have all the builds to pass:

1. Adjust to nvdiffrast latest modifications, removing opengl as an option and setting TORCH_CUDA_ARCH_LIST before building, I also tried to remove some apt-get install that were only for opengl
2. Fix some windows only typing issue with c++ files ( int / uint  not being the same length between windows and linux) recent pip issues with latest docker images (have to use `--no-build-isolation`, due to [PEP668](https://peps.python.org/pep-0668/))
3. We now have a separated `[for windows base]` commit tag that will only trigger build of windows base docker images, those only have cuda installed and conda downloaded (python not specified yet). `[push windows base]`  to ""master"" (i.e they are tags with `-master` prefix instead of the branch). Windows full kaolin build will use the base docker image, from the branch if it exist, else from master. This is to shorten the builds job (installing cuda and somehow accepting conda TOS is taking a bit amount of time...)
4. Lots of fixes for docker windows, honestly it's gonna be hard for me to explain, this is mostly due to some changes in vs build tools?
5. I ensured we can build with latest pytorch and cuda and python with windows and linux