### PR TITLE
Add QR transform for skinning basis, weight normalization

### DIFF
--- a/kaolin/physics/common/collisions.py
+++ b/kaolin/physics/common/collisions.py
@@ -19,7 +19,7 @@ import warp as wp
 import warp.sparse as wps
 
 from kaolin.physics.simplicits.precomputed import sparse_collision_jacobian_matrix
-from kaolin.physics.utils.warp_utilities import _bsr_to_torch
+from kaolin.physics.utils.warp_utilities import _bsr_to_torch, _warp_csr_from_torch_dense
 
 __all__ = ['Collision']
 
@@ -593,7 +593,7 @@ class Collision:
 
         return
 
-    def get_jacobian(self, cp_w, cp_x0, cp_is_static=None):
+    def calculate_jacobian(self, cp_w, cp_x0, cp_is_static=None, qr_tfm=None):
         r""" Builds the jacobians of the collision points w.r.t the dofs. For contact pairs :math:`x_a \in \mathbb{R}^3, x_b \in \mathbb{R}^3`, the jacobians are:
 
         .. math::
@@ -607,13 +607,13 @@ class Collision:
             cp_w (wp.array2d(dtype=wp.float32)): Contact point skinning weights of size :math:`(\text{num_pts}, \text{num_handles})`
             cp_x0 (wp.array(dtype=wp.vec3)): Rest contact point positions of size :math:`(\text{num_pts}, 3)`
             cp_is_static (wp.array(dtype=int), optional): Array indicating which contact points are static (1 for static, 0 for dynamic). Defaults to None.
-        
+            qr_tfm (torch.Tensor, optional): Block-diagonal handle-DOF rotation that maps the raw (pre-QR) basis to the post-QR basis used for elastic/inertia terms. When provided, ``collision_J`` and ``collision_J_dense`` are rotated into the post-QR basis for gradient/Hessian assembly, while ``collision_J_a``/``collision_J_b`` are kept in the raw basis so the bounds kernel can still read meaningful per-DOF sparsity. Defaults to None.
+
         Note:
             The jacobian set by this function is a sparse matrix of size :math:`(3 \times \text{num_contacts}, 12 \times \text{num_handles})`.
         """
 
         # indices of the colliding point pairs
-        num_pts = self.num_contacts
         num_handles = cp_w.shape[1]
         if self.num_contacts == 0:
             num_rows = 0
@@ -629,9 +629,6 @@ class Collision:
 
             ind_a = wp.clone(self.collision_indices_a[:self.num_contacts])
             ind_b = wp.clone(self.collision_indices_b[:self.num_contacts])
-            
-            t_ind_a = wp.to_torch(ind_a)
-            t_ind_b = wp.to_torch(ind_b)
 
             J_a = sparse_collision_jacobian_matrix(cp_w, cp_x0, indices=ind_a, cp_is_static=cp_is_static)
             J_b = sparse_collision_jacobian_matrix(cp_w, cp_x0, indices=ind_b, cp_is_static=cp_is_static)
@@ -648,6 +645,19 @@ class Collision:
             self.collision_J_dense = _bsr_to_torch(self.collision_J).to_dense()
         else:
             self.collision_J_dense = torch.zeros(self.collision_J.shape, device=wp.device_to_torch(self.collision_J.device), dtype=wp.dtype_to_torch(self.collision_J.dtype))
+
+        # QR mode: rotate the consumer-facing collision_J / collision_J_dense into the
+        # post-QR basis. collision_J_a / collision_J_b stay raw so get_bounds can read
+        # the original LBS sparsity (a row-subset of pre-QR B with per-handle column
+        # blocks). The line search wraps _apply_bounds with the inverse rotation so the
+        # clamp still happens in the basis where the bounds were computed.
+        if qr_tfm is not None and self.num_contacts > 0:
+            self.collision_J_dense = self.collision_J_dense @ qr_tfm
+            # Match the (1, 4) block shape used elsewhere (e.g. simulation.py:140
+            # for sim_B), so bsr_mv downstream sees the same layout it did pre-QR.
+            self.collision_J = wps.bsr_copy(
+                _warp_csr_from_torch_dense(self.collision_J_dense), block_shape=(1, 4))
+            self.collision_J.nnz_sync()
 
         return
 

--- a/kaolin/physics/common/optimization.py
+++ b/kaolin/physics/common/optimization.py
@@ -42,18 +42,24 @@ def _red_to_full(wp_P, wp_red_x):
     else:
         return wp.array(wp_P @ wp_red_x).flatten()
 
-
-def _apply_bounds(direction, bounds, t):
+@torch.no_grad()
+def _apply_bounds(direction, bounds, t, bounds_qr_tfm=None, bounds_qr_tfm_inv=None):
     """Applies bounds to a search direction in optimization.
 
-    This function takes a search direction and scales it element-wise by the minimum 
-    of the provided bounds and current line search step size t. This ensures the optimization step respects 
+    This function takes a search direction and scales it element-wise by the minimum
+    of the provided bounds and current line search step size t. This ensures the optimization step respects
     any constraints defined by the bounds.
 
     Args:
         direction (torch.Tensor): The search direction vector
         bounds (torch.Tensor): Per-element bounds on the step size
-        t (float): Global line searchstep size scaling factor
+        t (float): Global line search step size scaling factor
+        bounds_qr_tfm (torch.Tensor, optional): When ``bounds`` were computed against a
+            Jacobian in a different DOF basis (e.g. the raw pre-QR basis while ``direction``
+            lives in the post-QR basis), this matrix rotates ``direction`` into the basis
+            where the clamp is meaningful. Must be paired with ``bounds_qr_tfm_inv``.
+        bounds_qr_tfm_inv (torch.Tensor, optional): Inverse of ``bounds_qr_tfm``. Used
+            to rotate the clamped step back into the basis ``direction`` came from.
 
     Returns:
         torch.Tensor: The bounded/scaled search direction
@@ -61,33 +67,57 @@ def _apply_bounds(direction, bounds, t):
     min_bounds = torch.min(bounds, torch.as_tensor(
         t, dtype=bounds.dtype, device=bounds.device))
 
-    updated_direction = direction * min_bounds
-    return updated_direction
+    if bounds_qr_tfm is None or bounds_qr_tfm_inv is None:
+        return direction * min_bounds
+
+    # Background:
+    # Updated direction lives in the post-QR (new) basis; bounds live in the raw (old) basis.
+    # Details:
+    # 1) Rotate direction into the old basis
+    # 2) Do the element-wise clamp there
+    # 3) Rotate the clamped step back to the new basis
+    # Vectors transform linearly under change of basis; bounds (an axis-aligned box) would not, 
+    # which is why we wrap the clamp instead of trying to transform bounds directly.
+
+    direction_old = bounds_qr_tfm @ direction
+    dz_old_step = direction_old * min_bounds
+    dz_new_step = bounds_qr_tfm_inv @ dz_old_step
+    return dz_new_step
 
 
 @torch.no_grad()
-def _line_search(func, x, wp_P, direction, gradient, initial_step_size, bounds, alpha=1e-3, beta=0.6, max_steps=10):
+def _line_search(func, x, wp_P, direction, gradient, initial_step_size, bounds,
+                 alpha=1e-3, beta=0.6, max_steps=10,
+                 bounds_qr_tfm=None, bounds_qr_tfm_inv=None):
     r"""Implements the simplest backtracking line search with the sufficient decrease Armijo condition
 
     Args:
         func (function): Optimization Energy/Loss function
         x (torch.Tensor): Optimization objective (the value you're optimizing)
+        wp_P (wps.bsr_matrix or None): Projection matrix mapping the reduced ``x`` back
+            to the full DOF space before calling ``func``. ``None`` means no projection.
         direction (torch.Tensor): Search direction
         gradient (torch.Tensor): Optimization gradient
         initial_step_size (float): Initial step size
-        alpha (float, optional): LS parameter. Defaults to 1e-8.
-        beta (float, optional): LS parameter. Defaults to 0.3.
-        max_steps (int, optional): Max number of line search steps. Defaults to 20.
+        bounds (torch.Tensor): Per-element bounds on the step size; forwarded to ``_apply_bounds``.
+        alpha (float, optional): LS parameter. Defaults to 1e-3.
+        beta (float, optional): LS parameter. Defaults to 0.6.
+        max_steps (int, optional): Max number of line search steps. Defaults to 10.
+        bounds_qr_tfm (torch.Tensor, optional): Forwarded to ``_apply_bounds``; see that
+            function for the basis-change semantics.
+        bounds_qr_tfm_inv (torch.Tensor, optional): Forwarded to ``_apply_bounds``.
 
     Returns:
-        torch float: Optimal step size used to scale the search direction
+        torch.Tensor: The bounded search direction scaled by the chosen step size
+        (i.e. the update to add to ``x``), not a scalar step size.
     """
     t = initial_step_size  # Initial step size
     wp_x = _red_to_full(wp_P, wp.from_torch(x))
     f = func(wp_x)
 
     can_break = False
-    bounded_direction = _apply_bounds(direction, bounds, t)
+    bounded_direction = _apply_bounds(
+        direction, bounds, t, bounds_qr_tfm, bounds_qr_tfm_inv)
 
     for __ in range(max_steps):
         x_new = x + bounded_direction
@@ -100,14 +130,16 @@ def _line_search(func, x, wp_P, direction, gradient, initial_step_size, bounds, 
             else:
                 can_break = True
                 t = t / beta  # Increase the step size
-                bounded_direction = _apply_bounds(direction, bounds, t)
+                bounded_direction = _apply_bounds(
+                    direction, bounds, t, bounds_qr_tfm, bounds_qr_tfm_inv)
         else:
             t *= beta  # Reduce the step size
-            bounded_direction = _apply_bounds(direction, bounds, t)
+            bounded_direction = _apply_bounds(
+                direction, bounds, t, bounds_qr_tfm, bounds_qr_tfm_inv)
 
     return bounded_direction  # Return the final step size if max_iters is reached
 
-
+@torch.no_grad()
 def newtons_method(x,
                    energy_fcn,
                    gradient_fcn,
@@ -120,7 +152,9 @@ def newtons_method(x,
                    cg_tol=1e-4,
                    cg_iters=100,
                    conv_tol=1e-4,
-                   direct_solve=False):
+                   direct_solve=False,
+                   bounds_qr_tfm=None,
+                   bounds_qr_tfm_inv=None):
     r""" Newton's method optimizes for the updated dofs at the next time step. At each iteration, it computes the updated direction `dz`, 
     finds an appropriate step size, and updates the dofs. It continues to do this iteratively until the directional update is small which indicates the energy is minimized.
 
@@ -138,6 +172,8 @@ def newtons_method(x,
         cg_iters (int, optional): CG iterations. Defaults to 100.
         conv_tol (float, optional): Convergence tolerance. Defaults to 1e-4.
         direct_solve (bool, optional): Whether to use a dense direct solver, or a sparse CG solver. Defaults to False.
+        bounds_qr_tfm (torch.Tensor, optional): If apply_qr=True, this is the forward direction used in the line search's apply_bounds for collision bounds in the raw sparse-DOF basis. If apply_qr=False, this is None. Forwarded to ``_apply_bounds``; see that function for the basis-change semantics.
+        bounds_qr_tfm_inv (torch.Tensor, optional): If apply_qr=True, this is the inverse direction used in the line search's apply_bounds for collision bounds in the raw sparse-DOF basis. If apply_qr=False, this is None. Forwarded to ``_apply_bounds``.
 
     Returns:
         wp.array: Optimized objective of size :math:`(\text{num_dofs},)`
@@ -210,9 +246,11 @@ def newtons_method(x,
                                       direction=t_red_dx,
                                       gradient=t_red_g,
                                       initial_step_size=last_alpha,
-                                      bounds=t_bounds)
+                                      bounds=t_bounds,
+                                      bounds_qr_tfm=bounds_qr_tfm,
+                                      bounds_qr_tfm_inv=bounds_qr_tfm_inv)
 
-        t_red_x += bounded_update
+        t_red_x = t_red_x + bounded_update
 
         t_x = wp.to_torch(_red_to_full(P, wp.from_torch(t_red_x))) + t_x_kinematic 
         x = wp.from_torch(t_x)

--- a/kaolin/physics/simplicits/network.py
+++ b/kaolin/physics/simplicits/network.py
@@ -83,8 +83,17 @@ class SkinningModule(torch.nn.Module):
         Returns:
             torch.Tensor: The Jacobian of the skinning weights, of shape :math:`(N, \text{num_handles}, 3)`.
         """
-        jac_single = torch.func.jacrev(lambda x: self.compute_skinning_weights(x[None])[0])
-        return torch.vmap(jac_single)(pts)
+        if hasattr(self, 'grad'):
+            norm_pts = self._offset_scale(pts)
+            model_grad = self.grad(norm_pts)
+            model_grad = model_grad / (self.bb_max - self.bb_min)[None, None]
+            return torch.cat([
+                model_grad,
+                torch.zeros((model_grad.shape[0], 1, model_grad.shape[2]), device=pts.device)
+            ], dim=1)
+        else:
+            jac_single = torch.func.jacrev(lambda x: self.compute_skinning_weights(x[None])[0])
+            return torch.vmap(jac_single)(pts)
 
     @staticmethod
     def from_function(function: Callable, bb_min=0, bb_max=1):

--- a/kaolin/physics/simplicits/rkpm.py
+++ b/kaolin/physics/simplicits/rkpm.py
@@ -132,7 +132,7 @@ class SimplicitsRKPM(SkinningModule):
        
             self.num_nodes = pts.shape[0]
             node_indices = torch.arange(0, pts.shape[0], device=device)
-            evecs = nn.Parameter(torch.zeros(self.num_nodes, self.num_handles, dtype=self.dtype, device=self.evecs.device))
+            evecs = nn.Parameter(torch.zeros(self.num_nodes, self.num_handles, dtype=self.dtype, device=device))
             self.register_parameter("evecs", evecs)
             self.evecs.requires_grad = False
         else:
@@ -263,6 +263,34 @@ class SimplicitsRKPM(SkinningModule):
         grad = torch.einsum("nNd,Nc->ncd", grad_phi, self.evecs)  # (n, D, C)
         return grad.to(dtype=out_dtype)
 
+@torch.compile(fullgraph=True)
+def compiled_func_x(x, nodes, radius):
+    r"""Uncorrected Gaussian RBF kernel evaluated at input locations.
+
+    Args:
+        x (torch.Tensor): Query points of shape :math:`(n, d)`.
+        nodes (torch.Tensor): RBF node centers of shape :math:`(N, d)`.
+        radius (torch.Tensor): Per-node support radii of shape :math:`(N,)`.
+
+    Returns:
+        torch.Tensor: Kernel values of shape :math:`(n, N)`.
+    """
+    r = torch.cdist(x, nodes)
+    return torch.exp(-(r / radius.unsqueeze(0)) ** 2)
+
+@torch.compile(fullgraph=True)
+def compiled_phi_x(Cx, Pn, func_x):
+    r"""Assembles RKPM corrected shape functions from polynomial coefficients and the RBF.
+
+    Args:
+        Cx (torch.Tensor): Polynomial correction coefficients of shape :math:`(n, P)`.
+        Pn (torch.Tensor): Polynomial basis at nodes of shape :math:`(N, P)`.
+        func_x (torch.Tensor): Uncorrected RBF values of shape :math:`(n, N)`.
+
+    Returns:
+        torch.Tensor: Corrected shape functions of shape :math:`(n, N)`.
+    """
+    return (Cx @ Pn.T) * func_x  # (n, P) @ (P, N) -> (n, N)
 
 class RKPM(nn.Module):
     r"""Reproducing Kernel Particle Method (RKPM) function module.
@@ -315,19 +343,6 @@ class RKPM(nn.Module):
             self.radius.data.copy_(radius)
         self.initialized = True
 
-    def func_r(self, r):
-        r"""Evaluates the uncorrected radial basis kernel as a function of distance.
-
-        Args:
-            r (torch.Tensor): Distances from query points to nodes of shape
-                :math:`(n, N)`.
-
-        Returns:
-            torch.Tensor: Kernel values of shape :math:`(n, N)`.
-        """
-        # uncorrected RBF kernel, as a function of radius
-        return torch.exp(-(r / self.radius) ** 2)
-    
     def func_x(self, x):
         r"""Evaluates the uncorrected radial basis kernel at input locations.
 
@@ -338,8 +353,7 @@ class RKPM(nn.Module):
             torch.Tensor: Kernel values of shape :math:`(n, N)`.
         """
         # uncorrected RBF kernel, as a function of input location
-        r = torch.linalg.norm(x[:, None, :] - self.nodes[None, :, :], dim=-1)
-        return self.func_r(r)
+        return compiled_func_x(x, self.nodes, self.radius)
     
     def dfunc_dx(self, x):
         r"""Computes the spatial gradient of the uncorrected radial basis kernel.
@@ -428,7 +442,7 @@ class RKPM(nn.Module):
         Mx = torch.einsum("nN,Nij->nij", func_x, Pn_PnT)  # (n, P, P)
         Px = self.polynomial(x)  # (n, P)
         Cx = torch.linalg.solve(Mx, Px)  # (n, P)
-        phi_x = (Cx @ Pn.T) * func_x  # (n, P) @ (P, N) -> (n, N)
+        phi_x = compiled_phi_x(Cx, Pn, func_x) #(Cx @ Pn.T) * func_x  # (n, P) @ (P, N) -> (n, N)
         return phi_x
 
     def grad_phi(self, x):

--- a/kaolin/physics/simplicits/simulation.py
+++ b/kaolin/physics/simplicits/simulation.py
@@ -15,15 +15,15 @@
 
 import logging
 import warnings
-from typing import Literal, Any, Union
+from typing import Literal, Union
 
 import warp as wp
 import warp.sparse as wps
 import numpy as np
 import torch
-import kaolin
 
 from functools import partial
+from scipy.linalg import qr
 
 from ..utils import warp_utilities, torch_utilities
 
@@ -55,12 +55,26 @@ class SimulatedObject(SkinnedPhysicsPoints):
     def __init__(self, pts, yms, prs, rhos, appx_vol, skinning_weights, dwdx,
                  renderable: SkinnedPointsProtocol = None,
                  init_transform=None,
-                 is_kinematic=False):
+                 is_kinematic=False,
+                 normalize_weights_by_samples=False,
+                 apply_qr=False):
+
+        handle_norms = None
+        if normalize_weights_by_samples:
+            handle_norms = torch.linalg.norm(skinning_weights, dim=0).clamp(min=1e-10)
+            skinning_weights = skinning_weights / handle_norms.unsqueeze(0)
+            dwdx = dwdx / handle_norms.reshape(1, -1, 1)
+
+
         super().__init__(pts=pts, yms=yms, prs=prs, rhos=rhos, appx_vol=appx_vol,
                          skinning_weights=skinning_weights, dwdx=dwdx,
                          renderable=renderable)
+        self.handle_norms = handle_norms
+
         self.init_transform = init_transform
         self.is_kinematic = is_kinematic
+        self.normalize_weights_by_samples = normalize_weights_by_samples
+        self.apply_qr = apply_qr
 
         # TODO(vismay):
         # This is a live design question. We should discuss this with Gilles/Newton folks.
@@ -95,11 +109,83 @@ class SimulatedObject(SkinnedPhysicsPoints):
         self._B_dense = None
         self._dFdz_dense = None
 
+        # QR reads B/dFdz via the dense properties, so must run after they exist.
+        if apply_qr:
+            self._apply_qr_decomposition()
+
         # Let's initialize simulation state variables
         self.z = None
         self.z_prev = None
         self.z_dot = None
         self.reset_sim_state()
+        
+
+    def _apply_qr_decomposition(self):
+        r"""QR: orthogonalize B to reduce condition number of Newton system.
+
+        The simulator's linearized skinning map is :math:`\Delta\mathbf{x} = \mathbf{B}\,\mathbf{z}`,
+        where :math:`\mathbf{B}` is the sparse LBS Jacobian (built from skinning weights and rest
+        points) and :math:`\mathbf{z}` is the stacked per-handle DOFs (12 per handle: a :math:`3\times4`
+        affine block). Columns of the raw :math:`\mathbf{B}_{\text{old}}` are often nearly
+        dependent, which hurts conditioning of :math:`\mathbf{B}^\top\mathbf{M}\mathbf{B}` and of
+        Newton solves.
+
+        Column-pivoted economic QR factorizes
+
+        .. math::
+           \mathbf{B}_{\text{old}}\,\boldsymbol{\Pi} = \mathbf{Q}\,\mathbf{R},
+
+        with :math:`\mathbf{Q}` orthonormal-columned, :math:`\mathbf{R}` upper-triangular, and
+        :math:`\boldsymbol{\Pi}` a column permutation. Define the basis-change matrix
+
+        .. math::
+           \mathbf{K} \equiv \boldsymbol{\Pi}\,\mathbf{R}^{-1} \quad(\text{stored as ``qr\_tfm``}),
+
+        so :math:`\mathbf{B}_{\text{old}}\,\mathbf{K} = \mathbf{Q}`. The stored LBS operator becomes
+        :math:`\mathbf{B}_{\text{new}} = \mathbf{Q}`, and the internal DOFs :math:`\mathbf{z}'`
+        relate to the original :math:`\mathbf{z}` by :math:`\mathbf{z} = \mathbf{K}\,\mathbf{z}'`.
+        The reachable set of linearized motions is unchanged — this is a reparameterization, not a
+        physics change. The inverse direction (used in the line search's apply_bounds for collision 
+        bounds in the raw sparse-DOF basis) is stored as ``qr_tfm_inv = R @ pmat.T``, with
+        ``qr_tfm @ qr_tfm_inv = I``.
+
+        Elasticity derivatives are transformed by the chain rule:
+        :math:`\partial\mathbf{F}/\partial\mathbf{z}' = (\partial\mathbf{F}/\partial\mathbf{z})\,\mathbf{K}`,
+        applied here as ``dFdz_dense @ qr_tfm``. Initial-state solve uses a least-squares fit
+        of :math:`\mathbf{B}_{\text{new}}\mathbf{z}'` to the transformed rest positions
+        (see ``reset_sim_state``). When exporting per-handle affines in the original column space
+        (e.g. to drive unnormalized renderable skinning weights), ``qr_tfm`` is applied to
+        :math:`\mathbf{z}'` — see ``_get_object_transforms_internal``.
+        """
+
+        # TODO(Donglai): Could this be implemented entirely on the GPU?
+
+        B_dense = self.B_dense
+        np_B = B_dense.detach().cpu().numpy()
+        _, np_R, np_P = qr(np_B, mode='economic', pivoting=True)
+        pmat = torch.eye(np_B.shape[1], device=self.device, dtype=self.dtype)[:, np_P]
+        R = torch.from_numpy(np_R).to(device=self.device, dtype=self.dtype)
+        self.qr_tfm = pmat @ torch.linalg.solve_triangular(
+            R, torch.eye(R.shape[0], device=R.device, dtype=R.dtype), upper=True)
+        # qr_tfm_inv = R @ P^T; satisfies qr_tfm @ qr_tfm_inv = I.
+        # Used to map vectors from the post-QR z basis back to the pre-QR z basis
+        # (and the inverse direction) so the collision bounds can clamp in the
+        # original basis where the per-DOF sparsity is meaningful.
+        self.qr_tfm_inv = R @ pmat.T
+
+        Q_dense = B_dense @ self.qr_tfm
+        self.B = wps.bsr_copy(warp_utilities._warp_csr_from_torch_dense(Q_dense), block_shape=(1, 4))
+        self.B.nnz_sync()
+        self._B_dense = Q_dense
+
+        # Kinematic objects keep dFdz as a sparse zero matrix (allocated at construction);
+        # orthogonalizing zeros yields zeros, so skip the dense materialization to avoid
+        # allocating a (9*N, 12*H) tensor that can OOM on large objects.
+        if not self.is_kinematic:
+            dFdz_dense = self.dFdz_dense
+            self._dFdz_dense = dFdz_dense @ self.qr_tfm
+            self.dFdz = warp_utilities._warp_csr_from_torch_dense(self._dFdz_dense)
+            self.dFdz.nnz_sync()
 
     @property
     def B_dense(self):
@@ -117,7 +203,8 @@ class SimulatedObject(SkinnedPhysicsPoints):
         return self._dFdz_dense
 
     @classmethod
-    def from_skinned_physics_points(cls, phys_pts: SkinnedPhysicsPoints, init_transform, is_kinematic=False):
+    def from_skinned_physics_points(cls, phys_pts: SkinnedPhysicsPoints, init_transform, is_kinematic=False,
+                                    normalize_weights_by_samples=False, apply_qr=False):
         """
         Creates simulation object given skinned physics points, minimal data needed for Simplicits simulation
         (e.g. this data can be read from disk).
@@ -126,6 +213,8 @@ class SimulatedObject(SkinnedPhysicsPoints):
             phys_pts (SkinnedPhysicsPoints): SkinnedPhysicsPoints object to use to define SimulatedObject properties.
             init_transform: Initial transform of the SimulatedObject.
             is_kinematic: If true, the object will be kinematic in the scene. Default: False.
+            normalize_weights_by_samples: If true, normalize skinning weights by L2 norm for better conditioning. Default: False.
+            apply_qr: If true, apply QR decomposition to orthogonalize the LBS basis. Default: False.
 
         Returns:
             (SimulatedObject): SimulatedObject object.
@@ -134,18 +223,24 @@ class SimulatedObject(SkinnedPhysicsPoints):
                    rhos=phys_pts.rhos, appx_vol=phys_pts.appx_vol,
                    skinning_weights=phys_pts.skinning_weights, dwdx=phys_pts.dwdx,
                    renderable=phys_pts.renderable,
-                   init_transform=init_transform, is_kinematic=is_kinematic)
+                   init_transform=init_transform, is_kinematic=is_kinematic,
+                   normalize_weights_by_samples=normalize_weights_by_samples, apply_qr=apply_qr)
 
     def reset_sim_state(self):
         r"""Reset the simulation state. Object's handle transforms are set back to initial deformations.
         This does not reset any material parameters or simplicits object parameters.
         """
 
-        self.z = torch.zeros(self.num_handles * 12, dtype=self.dtype, device=self.device)
-
-        # Sets the final (constant) handle
         if self.init_transform is not None:
-            self.z[-12:] = self.init_transform.flatten()
+            # The constant (last) handle has weight 1 (or 1/norm after normalization) at every
+            # point, so placing init_transform entirely in the last handle reproduces the
+            # desired rigid delta on every point. The lstsq route used to do this implicitly
+            # but introduced float32 noise; this closed form is exact in every case.
+            z_pre_qr = torch.zeros(self.num_handles * 12, dtype=self.dtype, device=self.device)
+            scale = self.handle_norms[-1].detach() if self.normalize_weights_by_samples else 1.0
+            z_pre_qr[-12:] = self.init_transform.flatten() * scale
+            # Map from post-normalization, pre-QR basis to post-QR basis: z' = qr_tfm_inv @ z.
+            self.z = self.qr_tfm_inv @ z_pre_qr if self.apply_qr else z_pre_qr
 
         self.z_prev = self.z.clone().detach()
         self.z_dot = torch.zeros_like(self.z, device=self.device)
@@ -170,15 +265,12 @@ class SimplicitsScene:
         cg_tol=1e-4,
         cg_iters=100,
         conv_tol=1e-4):
-        r"""Initializes a simplicits scene. SimplicitsObjects can be added to the scene. 
-        Scene forces such as floor and gravity can be set on the scene. 
+        r"""Initializes a simplicits scene. SimplicitsObjects can be added to the scene.
+        Scene forces such as floor and gravity can be set on the scene.
         The scene defaults to using float32 for all computations.
 
         Args:
             device (str, optional): Defaults to 'cuda'.
-            dtype (torch.dtype, optional): Defaults to torch.float. Must be torch.float32 — the
-                underlying warp sparse infrastructure (B, dFdz, mass matrix, sim state arrays)
-                is hard-coded to wp.float32, so float64 is unsupported.
             direct_solve (bool, optional): Whether to use direct solve for linear system. Defaults to True.
             use_cuda_graphs (bool, optional): Whether to use cuda graphs. Defaults to False.
             timestep (float, optional): Sim time-step. Defaults to 0.03.
@@ -232,6 +324,10 @@ class SimplicitsScene:
         self.sim_rhos = None         # wp.array(num_qp, dtype=wp.float32)
         self.sim_vols = None         # wp.array(num_qp, dtype=wp.float32)
         self.sim_masses = None       # wp.array(num_qp, dtype=wp.float32)
+
+        self.sim_qr_tfm = None         # full (12*total_H, 12*total_H) rotation; applied to collision_J once per detection
+        self.sim_qr_tfm_red = None     # reduced (kinematic objects projected out) variant for line-search wrap
+        self.sim_qr_tfm_inv_red = None # reduced inverse variant for line-search wrap
 
         # DOFs
         self.sim_z = None         # wp.array(num_handles*12, dtype=wp.float32)
@@ -288,6 +384,10 @@ class SimplicitsScene:
         self._ready_for_sim = False
 
     def _compute_sim_constants(self):  # pragma: no cover
+        if len(self.sim_obj_dict) == 0:
+            raise RuntimeError(
+                'Cannot prepare simulation for an empty scene; call add_object() first.')
+           
         _num_qp = []
         _num_cp = []
         _num_handles = []
@@ -374,6 +474,43 @@ class SimplicitsScene:
         self.sim_pts = wp.from_torch(
             torch.cat(_stacked_pts, dim=0).contiguous(), dtype=wp.vec3)
         self.sim_pts_flat = wp.array(self.sim_pts, dtype=wp.float32).flatten()
+
+        # Block-diagonal QR rotation across objects. sim_skinning_weights is built from
+        # raw (pre-QR) weights, so the collision Jacobian comes out in the pre-QR basis;
+        # sim_qr_tfm rotates it into the post-QR basis used by sim_B / sim_dFdz / z.
+        # Identity blocks fill in for objects without apply_qr, so non-QR scenes still
+        # see a single uniform multiply. None when no object uses QR (fast path).
+        #
+        # sim_qr_tfm_red / _inv_red are the same matrix family with kinematic-object
+        # blocks dropped, sized to match the kinematic-projected (reduced) DOF vector
+        # that the Newton line search operates on. Both directions are needed because
+        # the bounds wrap is a round trip: forward-rotate direction into the raw basis,
+        # element-wise clamp there, inverse-rotate the clamped step back to the new basis.
+        if any(obj.apply_qr for obj in self.sim_obj_dict.values()):
+            _rinv_blocks = []
+            _rinv_red_blocks = []
+            _rinv_red_inv_blocks = []
+            for obj in self.sim_obj_dict.values():
+                dof_dim = 12 * obj.num_handles
+                if obj.apply_qr:
+                    rinv = obj.qr_tfm
+                    rinv_inv = obj.qr_tfm_inv
+                else:
+                    rinv = torch.eye(dof_dim, device=self.device, dtype=self.dtype)
+                    rinv_inv = rinv
+                _rinv_blocks.append(rinv)
+                if not obj.is_kinematic:
+                    _rinv_red_blocks.append(rinv)
+                    _rinv_red_inv_blocks.append(rinv_inv)
+            self.sim_qr_tfm = torch.block_diag(*_rinv_blocks).contiguous()
+            self.sim_qr_tfm_red = (
+                torch.block_diag(*_rinv_red_blocks).contiguous() if _rinv_red_blocks else None)
+            self.sim_qr_tfm_inv_red = (
+                torch.block_diag(*_rinv_red_inv_blocks).contiguous() if _rinv_red_inv_blocks else None)
+        else:
+            self.sim_qr_tfm = None
+            self.sim_qr_tfm_red = None
+            self.sim_qr_tfm_inv_red = None
 
         mus, lams = to_lame(
             torch.cat(_stacked_yms, dim=0).contiguous(),
@@ -483,8 +620,45 @@ class SimplicitsScene:
         obj.init_transform = relative_transform
         self.reset_scene() # quick way to update the scene's dofs
 
+    def _get_object_transforms_internal(self, object_id):
+        """Returns transforms in the same space as ``self.skinning_weights``.
+
+        When ``normalize_weights_by_samples=True``, ``self.skinning_weights`` is
+        normalized in-place by weight normalization; this method
+        returns transforms in that same normalized space (suitable for LBS with
+        ``self.skinning_weights``). 
+        
+        When ``apply_qr=True``, the QR basis change
+        is undone via ``qr_tfm`` so the result is still in the row-space of
+        the (possibly normalized) ``B``. Use ``get_object_transforms`` instead
+        when pairing with the unnormalized ``renderable.skinning_weights``.
+
+        Args:
+            object_id (int): Id of the object to get the transforms of
+
+        Returns:
+            torch.Tensor: Torch tensor of size :math:`(\text{num_handles}, 3, 4)` for transforms.
+        """
+        obj = self.sim_obj_dict[object_id]
+        if self.sim_z is not None:
+            wp_tfms = wp.clone(self.sim_z[self.object_to_z_map[object_id]])
+            tfms = wp.to_torch(wp_tfms, requires_grad=False).reshape((-1, 3, 4))
+        else:
+            # Pre-sim: read from obj.z, which reset_sim_state populates correctly
+            # for every (apply_qr, normalize_weights_by_samples) combination.
+            tfms = obj.z.detach().clone().view(-1, 3, 4)
+        if obj.apply_qr:
+            tfms = (obj.qr_tfm @ tfms.flatten()).view(-1, 3, 4)
+
+        padding = torch.zeros(tfms.shape[0], 1, 4, device=self.device, dtype=self.dtype)
+        padding[:, 0, 3] = 1.0
+        return torch.cat([tfms, padding], dim=1)
+
     def get_object_transforms(self, object_id):
-        """Returns the current 4x4 padded *relative* transforms.
+        """Returns the current 4x4 padded *relative* transforms in raw (physical) space.
+
+        Undoes any internal normalization (weight norms, QR) so the transforms
+        can be used with unnormalized skinning weights (e.g. rendered points).
 
         Args:
             object_id (int): Id of the object to get the transforms of
@@ -492,17 +666,12 @@ class SimplicitsScene:
         Returns:
             torch.Tensor: Torch tensor of size :math:`(\text{num_handles}, 4, 4)` for relative transforms.
         """
-        tfms = None
-        if self.sim_z is not None:
-            wp_tfms = wp.clone(self.sim_z[self.object_to_z_map[object_id]])
-            tfms = wp.to_torch(wp_tfms, requires_grad=False).reshape((-1, 3, 4))
-        else:
-            tfms = torch.zeros(self.sim_obj_dict[object_id].num_handles, 3, 4, device=self.device, dtype=self.dtype)
-            tfms[-1] = self.sim_obj_dict[object_id].init_transform.reshape(-1, 3, 4)
-
-        padding = torch.zeros(tfms.shape[0], 1, 4, device=self.device, dtype=self.dtype)
-        padding[:, 0, 3] = 1.0
-        return torch.cat([tfms, padding], dim=1)
+        tfms = self._get_object_transforms_internal(object_id)
+        # Un-normalize: z_raw = z_norm / norms
+        if self.sim_obj_dict[object_id].normalize_weights_by_samples:
+            norms = self.sim_obj_dict[object_id].handle_norms
+            tfms[:, :3, :] = tfms[:, :3, :] / norms.view(-1, 1, 1)
+        return tfms
 
     def _add_object(self, simulated_object: SimulatedObject):
         if self._ready_for_forces:
@@ -512,7 +681,8 @@ class SimplicitsScene:
         self.current_id += 1
         return self.current_id - 1
 
-    def add_object(self, sim_object: Union[SimplicitsObject, SkinnedPhysicsPoints], num_qp=None, init_transform=None, is_kinematic=False, renderable_pts=None):
+    def add_object(self, sim_object: Union[SimplicitsObject, SkinnedPhysicsPoints], num_qp=None, init_transform=None, is_kinematic=False, renderable_pts=None,
+                   normalize_weights_by_samples=True, apply_qr=True):
         r"""Adds a simplicits object to the scene as a SimulatedObject. Can add a just trained SimplicitsObject which
         contains a skinning weight field, or can also accept a baked version, sufficient for simulation.
 
@@ -529,6 +699,13 @@ class SimplicitsScene:
                 When provided and sim_object is a SimplicitsObject, skinning weights are baked for these
                 points and stored in the SimulatedObject for use with get_object_deformed_pts(..., points='rendered').
                 This is not to be used with already baked SkinnedPhysicsPointsProtocol.
+            normalize_weights_by_samples (bool): If True, L2-normalize skinning weights over the sample set
+                for better conditioning of the Newton system. Default: True.
+            apply_qr (bool): If True, apply QR decomposition to orthogonalize the LBS basis. Default: True.
+
+        Returns:
+            int: The id assigned to the newly added object, usable with the other
+            ``get_object_*`` / ``set_object_*`` methods on this scene.
         """
         # Check if init transform is a 3x4 or 4x4 tensor, convert to 3x4 if necessary
         # Subtract identity transform from init transform to get relative transform
@@ -537,19 +714,20 @@ class SimplicitsScene:
         else:
             relative_transform = torch.zeros(3, 4, device=self.device, dtype=self.dtype)
 
-
         if isinstance(sim_object, SimplicitsObject):
             # For SimplicitsObject, bake directly with num_qp to avoid double subsampling
             assert num_qp is not None, "'num_qp' must be provided with SimplicitsObject"
             baked = sim_object.bake(num_qps=num_qp, renderable_pts=renderable_pts)
             simulated_object = SimulatedObject.from_skinned_physics_points(
-                baked, init_transform=relative_transform, is_kinematic=is_kinematic)
+                baked, init_transform=relative_transform, is_kinematic=is_kinematic,
+                normalize_weights_by_samples=normalize_weights_by_samples, apply_qr=apply_qr)
         else:
             # For already baked SkinnedPhysicsPointsProtocol, subsample if needed
             assert renderable_pts is None, "'renderable_pts' are not supported for already baked SkinnedPhysicsPointsProtocol"
             sampled = sim_object.subsample(num_pts=num_qp) if num_qp is not None else sim_object
             simulated_object = SimulatedObject.from_skinned_physics_points(
-                sampled, init_transform=relative_transform, is_kinematic=is_kinematic)
+                sampled, init_transform=relative_transform, is_kinematic=is_kinematic,
+                normalize_weights_by_samples=normalize_weights_by_samples, apply_qr=apply_qr)
 
         return self._add_object(simulated_object)
     
@@ -729,9 +907,15 @@ class SimplicitsScene:
                                            cp_obj_ids=self.qp_to_object_map,
                                            cp_is_static=None)
         
-        # Builds collision jacobian    
-        collision_struct.get_jacobian(
-            cp_w=self.sim_skinning_weights, cp_x0=self.sim_pts, cp_is_static=self.qp_is_kinematic)
+        # Builds collision jacobian. sim_skinning_weights is the raw (pre-QR) block-diag
+        # weight matrix; collision_J_a/_b stay in this basis (so the bounds kernel reads
+        # the original per-handle sparsity), while collision_J is rotated into the post-QR
+        # basis to match sim_B for gradient/Hessian assembly.
+        collision_struct.calculate_jacobian(
+            cp_w=self.sim_skinning_weights, 
+            cp_x0=self.sim_pts,
+            cp_is_static=self.qp_is_kinematic, 
+            qr_tfm=self.sim_qr_tfm)
 
     def _build_preconditioner(self, lhs):  # pragma: no cover
         return warp_utilities._build_preconditioner(lhs)
@@ -903,7 +1087,7 @@ class SimplicitsScene:
         # 3. Concatenate the hessians into a big list [(i,i,H_ii), (i,j,H_ij), ....]
 
         num_pts = int(self.sim_B.shape[0]/3)
-        num_dofs = self.sim_B.shape[1]
+
         # Names of gradients to assemble
         pt_names = list(self.force_dict["pt_wise"].keys())
         defo_grad_names = list(self.force_dict["defo_grad_wise"].keys())
@@ -996,8 +1180,7 @@ class SimplicitsScene:
                   dt, wp_z, wp_z_prev, wp_z_dot], outputs=[delta_dz])
         return delta_dz
 
-    def _newton_E(self, wp_z, wp_z_prev, wp_z_dot,
-                  wp_B, wp_BMB, dt, wp_dFdz, defo_grad_energies=None, pt_wise_energies=None):  # pragma: no cover
+    def _newton_E(self, wp_z, wp_z_prev, wp_z_dot, wp_B, dt):  # pragma: no cover
         r"""Backward's euler energy used in newton's method
 
         Args:
@@ -1005,11 +1188,7 @@ class SimplicitsScene:
             wp_z_prev (wp.array): Previous transforms
             wp_z_dot (wp.array): Time derivative of transforms
             wp_B (wp.sparse.bsr_matrix): Precomputed Jacobian, dx/dz
-            wp_BMB (wp.sparse.bsr_matrix): Precomputed z-wise mass matrix.
             dt (float): Timestep
-            wp_dFdz (wp.sparse.bsr_matrix): Precomputed jacobian
-            defo_grad_energies (list, optional): List of energies. Defaults to [].
-            pt_wise_energies (list, optional): List of energies. Defaults to [].
 
         Returns:
             float: Backward's euler energy scalar.
@@ -1021,7 +1200,7 @@ class SimplicitsScene:
         wp_newton_energy = ke + dt*dt * pe_sum
         return wp_newton_energy
 
-    def _newton_G(self, wp_z, wp_z_prev, wp_z_dot, wp_B, wp_BMB, dt, wp_dFdz, defo_grad_gradients=None, pt_wise_gradients=None):  # pragma: no cover
+    def _newton_G(self, wp_z, wp_z_prev, wp_z_dot, wp_B, wp_BMB, dt):  # pragma: no cover
         r"""Backward's euler gradient used in newton's method
 
         Args:
@@ -1031,9 +1210,6 @@ class SimplicitsScene:
             wp_B (wp.sparse.bsr_matrix): Precomputed Jacobian, dx/dz
             wp_BMB (wp.sparse.bsr_matrix): Precomputed z-wise mass matrix.
             dt (float): Timestep
-            wp_dFdz (wp.sparse.bsr_matrix): Precomputed jacobian
-            defo_grad_gradients (list, optional): List of gradients. Defaults to [].
-            pt_wise_gradients (list, optional): List of gradients. Defaults to [].
 
         Returns:
             wp.array: Backward's euler gradient.
@@ -1048,19 +1224,14 @@ class SimplicitsScene:
 
         return newton_gradient
 
-    def _newton_H(self, wp_z, wp_z_prev, wp_z_dot, wp_B, wp_BMB, dt, wp_dFdz, defo_grad_hessians=None, pt_wise_hessians=None):  # pragma: no cover
+    def _newton_H(self, wp_z, wp_B, wp_BMB, dt):  # pragma: no cover
         r"""Backward's euler hessian used in newton's method
 
         Args:
             wp_z (wp.array): Transforms
-            wp_z_prev (wp.array): Previous transforms
-            wp_z_dot (wp.array): Time derivative of transforms
             wp_B (wp.sparse.bsr_matrix): Precomputed Jacobian, dx/dz
             wp_BMB (wp.sparse.bsr_matrix): Precomputed z-wise mass matrix.
             dt (float): Timestep
-            wp_dFdz (wp.sparse.bsr_matrix): Precomputed jacobian
-            defo_grad_hessians (list, optional): List of hessians. Defaults to [].
-            pt_wise_hessians (list, optional): List of hessians. Defaults to [].
 
         Returns:
             wp.sparse.bsr_matrix: Backward's euler hessian.
@@ -1111,13 +1282,16 @@ class SimplicitsScene:
                     f'Pass renderable_pts when calling add_object().')
             pts = sim_obj.renderable.pts
             skinning_weights = sim_obj.renderable.skinning_weights
+            tfms = self.get_object_transforms(obj_idx)[:, :3, :]
         elif points == 'simulated':
             pts = sim_obj.pts
             skinning_weights = sim_obj.skinning_weights
-        else:
-            raise ValueError('Only supports "rendered" or "simulated" points')
+            # sim_obj.skinning_weights is in normalized space when
+            # normalize_weights_by_samples=True; pair it with transforms in the
+            # matching space.
+            tfms = self._get_object_transforms_internal(obj_idx)[:, :3, :]
+        
 
-        tfms = self.get_object_transforms(obj_idx)[:, :3, :]  # make 4x4 to 3x4
         return standard_lbs(pts, tfms.unsqueeze(0), skinning_weights).squeeze()
 
     def get_object_point_transforms(self, obj_idx,
@@ -1141,17 +1315,22 @@ class SimplicitsScene:
                     f'Object {obj_idx} has no renderable skinning weights. '
                     f'Pass renderable skinning weights when calling add_object().')
             skinning_weights = sim_obj.renderable.skinning_weights
+            transforms = self.get_object_transforms(obj_idx)
         elif points == 'simulated':
             skinning_weights = sim_obj.skinning_weights
-        else:
-            raise ValueError('Only supports "rendered" or "simulated" points')
-
-        transforms = self.get_object_transforms(obj_idx)
+            # sim_obj.skinning_weights is in normalized space when
+            # normalize_weights_by_samples=True; pair it with transforms in the
+            # matching space.
+            transforms = self._get_object_transforms_internal(obj_idx)
 
         # N x 4 x 4 = sum((N x H x 1 x 1) * (1 x H x 4 x 4), dim=1)
         per_pt_transforms = torch.sum(skinning_weights.unsqueeze(-1).unsqueeze(-1) * transforms, dim=1)
 
         per_pt_transforms[:, :3, :3] += torch.eye(3, 3, dtype=per_pt_transforms.dtype, device=per_pt_transforms.device).unsqueeze(0)
+
+        # Per-point affine: homogeneous row is [0, 0, 0, 1] by definition.
+        per_pt_transforms[:, 3, :] = 0
+        per_pt_transforms[:, 3, 3] = 1
 
         return per_pt_transforms
 
@@ -1176,14 +1355,13 @@ class SimplicitsScene:
         self.sim_z_prev = wp.clone(self.sim_z)
 
         more_partial_newton_E = partial(
-            self._newton_E, wp_B=self.sim_B, wp_BMB=self.sim_BMB, dt=self.timestep, wp_dFdz=self.sim_dFdz,
-            defo_grad_energies=None, pt_wise_energies=None, wp_z_prev=self.sim_z_prev, wp_z_dot=self.sim_z_dot)
+            self._newton_E, wp_B=self.sim_B, dt=self.timestep,
+            wp_z_prev=self.sim_z_prev, wp_z_dot=self.sim_z_dot)
         more_partial_newton_G = partial(
-            self._newton_G, wp_B=self.sim_B, wp_BMB=self.sim_BMB, dt=self.timestep, wp_dFdz=self.sim_dFdz,
-            defo_grad_gradients=None, pt_wise_gradients=None, wp_z_prev=self.sim_z_prev, wp_z_dot=self.sim_z_dot)
+            self._newton_G, wp_B=self.sim_B, wp_BMB=self.sim_BMB, dt=self.timestep,
+            wp_z_prev=self.sim_z_prev, wp_z_dot=self.sim_z_dot)
         more_partial_newton_H = partial(
-            self._newton_H, wp_B=self.sim_B, wp_BMB=self.sim_BMB, dt=self.timestep, wp_dFdz=self.sim_dFdz,
-            defo_grad_hessians=None, pt_wise_hessians=None, wp_z_prev=self.sim_z_prev, wp_z_dot=self.sim_z_dot)
+            self._newton_H, wp_B=self.sim_B, wp_BMB=self.sim_BMB, dt=self.timestep)
 
         ###########################################################
 
@@ -1200,7 +1378,9 @@ class SimplicitsScene:
             cg_tol=self.cg_tol,
             cg_iters=self.cg_iters,
             conv_tol=self.conv_tol,
-            direct_solve=self.direct_solve)
+            direct_solve=self.direct_solve,
+            bounds_qr_tfm=self.sim_qr_tfm_red, 
+            bounds_qr_tfm_inv=self.sim_qr_tfm_inv_red)
 
         self.sim_z_dot = wp.from_torch(
             (wp.to_torch(self.sim_z) - wp.to_torch(self.sim_z_prev)) / self.timestep)

--- a/kaolin/physics/simplicits/training.py
+++ b/kaolin/physics/simplicits/training.py
@@ -811,7 +811,7 @@ class SimplicitsObject(PhysicsPoints):
         from the generalized eigenvalue problem of the mass and stiffness matrices.
 
         Note:
-            If num_handles is set to 0, the object will be created as rigid instead of deformable.
+            If num_handles is set to 1, the object will be created as rigid instead of deformable.
 
         Args:
             physics_points (PhysicsPoints): PhysicsPoints object to be used for training.

--- a/tests/python/kaolin/physics/common/test_collisions.py
+++ b/tests/python/kaolin/physics/common/test_collisions.py
@@ -204,7 +204,7 @@ def test_collision_jacobian(test_scenes):
                                      friction=friction)  # other parameters are default
     
     collision.detect_collisions(dx, x0, obj_ids, is_static)
-    collision.get_jacobian(weights, x0, is_static)
+    collision.calculate_jacobian(weights, x0, is_static)
     collision_jacobian = collision.collision_J_dense
 
     if collision.num_contacts == 0:
@@ -437,7 +437,7 @@ def test_collision_bounds_indexing():
     assert collision.num_contacts == 2, \
         f"Expected exactly 2 contacts, got {collision.num_contacts}"
 
-    collision.get_jacobian(weights, x0, is_static)
+    collision.calculate_jacobian(weights, x0, is_static)
 
     J_a = collision.collision_J_a
     assert J_a.offsets.shape[0] >= 3 * 2 + 1

--- a/tests/python/kaolin/physics/simplicits/test_simplicits_vs_fem.py
+++ b/tests/python/kaolin/physics/simplicits/test_simplicits_vs_fem.py
@@ -286,3 +286,105 @@ def test_cantilever_beam_dFdz_consistency(device, dtype, cantilever_beam_dFdz_se
     _, simplicits_scene, data = cantilever_beam_dFdz_setup
     run_regression_test(simplicits_scene, data, tol=0.005, test_name="cantilever_beam_dFdz")
 
+
+@pytest.fixture(params=[False, True])
+@with_seed(0, 0, 0)
+def cantilever_beam_apply_qr_setup(request, device, dtype, cantilever_beam_data):
+    """Cantilever beam with rkpm object, parametrized over apply_qr."""
+    mesh, pts, yms, prs, rhos, object_vol, fem_data = cantilever_beam_data
+    phys = PhysicsPoints(pts=pts, yms=yms, prs=prs, rhos=rhos, appx_vol=object_vol)
+    simplicits_object = SimplicitsObject.create_with_rkpm(
+        physics_points=phys,
+        num_handles=32, num_nodes=1024, num_points=8192, dtype=torch.float64)
+    rendered_pts = fem_data["v0"]
+
+    scene = SimplicitsScene(device=device, timestep=0.05,
+                            max_newton_steps=10, max_ls_steps=20)
+    scene.newton_hessian_regularizer = 0
+    scene.direct_solve = True
+    scene.add_object(simplicits_object, num_qp=1024,
+                     apply_qr=request.param,
+                     renderable_pts=rendered_pts)
+    scene.set_scene_gravity(torch.tensor([0, 9.8, 0]))
+    scene.set_scene_floor(floor_height=-1.0, floor_axis=1,
+                          floor_penalty=10000.0, flip_floor=False)
+    scene.set_object_boundary_condition(
+        0, "right", lambda x: x[:, 0] >= 0.98, bdry_penalty=10000.0)
+    return mesh, scene, fem_data
+
+
+@pytest.fixture(params=[True, False])
+@with_seed(0, 0, 0)
+def cantilever_beam_normalize_setup(request, device, dtype, cantilever_beam_data):
+    """Cantilever beam with rkpm object, parametrized over normalize_weights_by_samples."""
+    mesh, pts, yms, prs, rhos, object_vol, fem_data = cantilever_beam_data
+    phys = PhysicsPoints(pts=pts, yms=yms, prs=prs, rhos=rhos, appx_vol=object_vol)
+    simplicits_object = SimplicitsObject.create_with_rkpm(
+        physics_points=phys,
+        num_handles=32, num_nodes=1024, num_points=8192, dtype=torch.float64)
+    rendered_pts = fem_data["v0"]
+
+    scene = SimplicitsScene(device=device, timestep=0.05,
+                            max_newton_steps=10, max_ls_steps=20)
+    scene.newton_hessian_regularizer = 0
+    scene.direct_solve = True
+    scene.add_object(simplicits_object, num_qp=1024,
+                     normalize_weights_by_samples=request.param,
+                     renderable_pts=rendered_pts)
+    scene.set_scene_gravity(torch.tensor([0, 9.8, 0]))
+    scene.set_scene_floor(floor_height=-1.0, floor_axis=1,
+                          floor_penalty=10000.0, flip_floor=False)
+    scene.set_object_boundary_condition(
+        0, "right", lambda x: x[:, 0] >= 0.98, bdry_penalty=10000.0)
+    return mesh, scene, fem_data
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_cantilever_beam_apply_qr_consistency(device, dtype, cantilever_beam_apply_qr_setup):
+    """Both apply_qr=False and True should pass the cantilever beam FEM regression test."""
+    _, simplicits_scene, data = cantilever_beam_apply_qr_setup
+    run_regression_test(simplicits_scene, data, tol=0.005, test_name="cantilever_beam_apply_qr")
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_cantilever_beam_normalize_consistency(device, dtype, cantilever_beam_normalize_setup):
+    """Both normalize_weights_by_samples=True and False should pass the cantilever beam FEM regression test."""
+    _, simplicits_scene, data = cantilever_beam_normalize_setup
+    run_regression_test(simplicits_scene, data, tol=0.01, test_name="cantilever_beam_normalize")
+
+
+@pytest.fixture
+@with_seed(0, 0, 0)
+def cantilever_beam_qr_and_normalize_setup(device, dtype, cantilever_beam_data):
+    """Cantilever beam with apply_qr=True AND normalize_weights_by_samples=True."""
+    mesh, pts, yms, prs, rhos, object_vol, fem_data = cantilever_beam_data
+    phys = PhysicsPoints(pts=pts, yms=yms, prs=prs, rhos=rhos, appx_vol=object_vol)
+    simplicits_object = SimplicitsObject.create_with_rkpm(
+        physics_points=phys,
+        num_handles=32, num_nodes=1024, num_points=8192, dtype=torch.float64)
+    rendered_pts = fem_data["v0"]
+
+    scene = SimplicitsScene(device=device, timestep=0.05,
+                            max_newton_steps=10, max_ls_steps=20)
+    scene.newton_hessian_regularizer = 0
+    scene.direct_solve = True
+    scene.add_object(simplicits_object, num_qp=1024,
+                     apply_qr=True,
+                     normalize_weights_by_samples=True,
+                     renderable_pts=rendered_pts)
+    scene.set_scene_gravity(torch.tensor([0, 9.8, 0]))
+    scene.set_scene_floor(floor_height=-1.0, floor_axis=1,
+                          floor_penalty=10000.0, flip_floor=False)
+    scene.set_object_boundary_condition(
+        0, "right", lambda x: x[:, 0] >= 0.98, bdry_penalty=10000.0)
+    return mesh, scene, fem_data
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_cantilever_beam_qr_and_normalize_consistency(device, dtype, cantilever_beam_qr_and_normalize_setup):
+    """apply_qr=True AND normalize_weights_by_samples=True together should still pass the cantilever beam FEM regression test."""
+    _, simplicits_scene, data = cantilever_beam_qr_and_normalize_setup
+    run_regression_test(simplicits_scene, data, tol=0.01, test_name="cantilever_beam_qr_and_normalize")

--- a/tests/python/kaolin/physics/simplicits/test_simulation.py
+++ b/tests/python/kaolin/physics/simplicits/test_simulation.py
@@ -110,7 +110,6 @@ class TestSimplicitsScene:
         # Create scene
         scene = SimplicitsScene(device=device)
 
-        # TODO: This will be fixed in another release
         # Set force without any objects in scene
         with pytest.raises(RuntimeError):
             scene.set_scene_gravity()
@@ -172,64 +171,6 @@ class TestSimplicitsScene:
         dyn_pts = scene.get_object_deformed_pts(0)
         mean_dyn_y = dyn_pts[:, 1].mean()
         assert mean_dyn_y < 10.0, f"Mean y coordinate of object {mean_dyn_y} has moved lower than 10 under gravity."
-
-    # def test_easy_api_add_object_scale(self, example_unit_cube_object, device, dtype):
-    #     x0, x0_sdfval, yms, prs, rhos, appx_vol = example_unit_cube_object
-    #     scale = 1.5
-
-    #     # Create RKPM object with 10 handles (non-trivial skinning weights + Jacobians)
-    #     from copy import deepcopy
-    #     obj1 = SimplicitsObject.create_with_rkpm(pts=x0, yms=yms, prs=prs, rhos=rhos, appx_vol=appx_vol,
-    #                                         num_handles=10, num_nodes=128, num_points=512)
-
-    #     # Scene 1: unscaled (fix seed so both scenes get same quadrature points)
-    #     scene1 = SimplicitsScene(device=device)
-    #     torch.manual_seed(42)
-    #     scene1.add_object(obj1, num_qp=100,
-    #                       init_transform=torch.tensor([[1, 0, 0, 0],
-    #                                                    [0, 1, 0, 3],
-    #                                                    [0, 0, 1, 0]], device=device, dtype=dtype))
-    #     scene1.set_scene_gravity()
-    #     scene1.set_scene_floor(floor_height=0.0, floor_penalty=10000.0)
-
-    #     # Scene 2: scaled, density /= scale^3 to keep same total mass
-    #     # Use deepcopy + override density so the weight function is identical
-    #     scaled_rhos = rhos / (scale ** 3)
-    #     obj2 = deepcopy(obj1)
-    #     obj2.rhos = scaled_rhos
-    #     scene2 = SimplicitsScene(device=device)
-    #     torch.manual_seed(42)
-    #     scene2.add_object(obj2, num_qp=100, scale=scale,
-    #                       init_transform=torch.tensor([[1, 0, 0, 0],
-    #                                                    [0, 1, 0, 3],
-    #                                                    [0, 0, 1, 0]], device=device, dtype=dtype))
-    #     scene2.set_scene_gravity()
-    #     scene2.set_scene_floor(floor_height=0.0, floor_penalty=10000.0)
-
-    #     # Compare dFdz matrices: rotation/scale cols identical, translation cols scaled by 1/s
-    #     dFdz1 = scene1.get_object(0).dFdz_dense
-    #     dFdz2 = scene2.get_object(0).dFdz_dense
-    #     num_handles = dFdz1.shape[1] // 12
-    #     for h in range(num_handles):
-    #         base = 12 * h
-    #         for col_offset in [0, 1, 2, 4, 5, 6, 8, 9, 10]:
-    #             assert torch.allclose(dFdz1[:, base + col_offset], dFdz2[:, base + col_offset], atol=1e-4), \
-    #                 f"dFdz rotation/scale column {base + col_offset} differs"
-    #         for col_offset in [3, 7, 11]:
-    #             assert torch.allclose(dFdz1[:, base + col_offset], dFdz2[:, base + col_offset] * scale, atol=1e-4), \
-    #                 f"dFdz translation column {base + col_offset} differs: expected scaled by 1/{scale}"
-
-    #     for _ in range(30):
-    #         scene1.run_sim_step()
-    #         scene2.run_sim_step()
-
-    #     pts1 = scene1.get_object_deformed_pts(0)
-    #     pts2 = scene2.get_object_deformed_pts(0)
-    #     pts2_normalized = pts2 / scale
-
-    #     # Not exact, but approximately similar (same mass, gravity, loose tolerance)
-    #     assert torch.allclose(pts1, pts2_normalized, atol=5.0), \
-    #         f"Normalized scaled deformed pts deviate too much from unscaled: max diff={torch.max(torch.abs(pts1 - pts2_normalized))}"
 
     def test_easy_api_set_scene_floor(self, scene_with_one_object):
         scene = scene_with_one_object
@@ -752,3 +693,189 @@ class TestSimplicitsScene:
         scene.set_scene_gravity()
         with pytest.raises(ValueError):
             scene.get_object_point_transforms(0, 'rendered')
+
+    # ---- 'simulated' branch under normalize_weights_by_samples=True ----
+    # Regression: 'simulated' uses self.skinning_weights (mutated by
+    # _apply_weight_normalization), so transforms must come from
+    # _get_object_transforms_internal (matching normalized space). 'rendered'
+    # uses renderable.skinning_weights (raw), so transforms must come from
+    # get_object_transforms (un-normalized). Pre-fix code paired normalized
+    # weights with un-normalized transforms, deflating the simulated
+    # deformation by 1/sqrt(num_qp).
+
+    def test_get_object_deformed_pts_simulated_normalize_weights(
+            self, example_rigid_cube, device, dtype):
+        """For a rigid translation, 'simulated' deformed pts must equal pts + t
+        regardless of the normalize_weights_by_samples flag."""
+        init = torch.tensor([[1, 0, 0, 0], [0, 1, 0, 10], [0, 0, 1, 0]],
+                            device=device, dtype=dtype)
+        scene = SimplicitsScene(device=device)
+        scene.add_object(example_rigid_cube, num_qp=200, init_transform=init,
+                         normalize_weights_by_samples=True)
+        scene.set_scene_gravity()  # initializes sim_z from per-object normalized z
+
+        rest = scene.get_object(0).pts
+        deformed = scene.get_object_deformed_pts(0, 'simulated')
+        expected = rest + torch.tensor([0., 10., 0.], device=device, dtype=dtype)
+        check_allclose(deformed, expected, atol=1e-5)
+
+    def test_get_object_point_transforms_simulated_normalize_weights(
+            self, example_rigid_cube, device, dtype):
+        """For a rigid translation, the affine block of 'simulated' per-point
+        transforms must equal the un-normalized rigid transform regardless of
+        the normalize_weights_by_samples flag."""
+        init = torch.tensor([[1, 0, 0, 0], [0, 1, 0, 10], [0, 0, 1, 0]],
+                            device=device, dtype=dtype)
+        scene = SimplicitsScene(device=device)
+        scene.add_object(example_rigid_cube, num_qp=200, init_transform=init,
+                         normalize_weights_by_samples=True)
+        scene.set_scene_gravity()
+
+        tfms = scene.get_object_point_transforms(0, 'simulated')
+        # Top 3 rows are what LBS consumes; assert they equal the un-normalized
+        # rigid translation. (Bottom row may not be [0,0,0,1] under normalized
+        # weights since sum_h w_h != 1, which is a separate concern.)
+        expected_top = torch.tensor([[1., 0., 0., 0.],
+                                     [0., 1., 0., 10.],
+                                     [0., 0., 1., 0.]], device=device, dtype=dtype)
+        check_allclose(tfms[:, :3, :],
+                       expected_top.unsqueeze(0).expand(tfms.shape[0], -1, -1),
+                       atol=1e-5)
+
+    # ---- Pre-sim get_object_transforms across (apply_qr, normalize_weights_by_samples) ----
+    # Regression: when no force is set yet, sim_z is None and
+    # _get_object_transforms_internal hits its else branch. The pre-fix branch
+    # placed init_transform at the last handle unconditionally, which is wrong
+    # under normalize_weights_by_samples (extra 1/handle_norm scaling slips
+    # through) and under apply_qr (obj.z is a lstsq solution spread across all
+    # handles in the QR basis, not init_transform at the last handle).
+
+    @pytest.mark.parametrize("apply_qr,normalize", [
+        (False, False), (False, True), (True, False), (True, True)],
+        ids=["plain", "normalize", "qr", "qr_and_normalize"])
+    def test_get_object_transforms_presim(self, example_rigid_cube, device, dtype,
+                                          apply_qr, normalize):
+        """Before any force is set (sim_z is None), get_object_transforms must
+        still return the un-normalized relative transform regardless of which
+        conditioning flags are enabled. For a rigid (single-handle) object the
+        returned (num_handles, 4, 4) tensor must match the relative transform
+        broadcast across handles."""
+        init = torch.tensor([[1, 0, 0, 0], [0, 1, 0, 10], [0, 0, 1, 0]],
+                            device=device, dtype=dtype)
+        scene = SimplicitsScene(device=device)
+        scene.add_object(example_rigid_cube, num_qp=200, init_transform=init,
+                         normalize_weights_by_samples=normalize, apply_qr=apply_qr)
+
+        # Pre-sim: no force has been set, so scene.sim_z is None and the else
+        # branch in _get_object_transforms_internal runs.
+        assert scene.sim_z is None
+        tfms = scene.get_object_transforms(0)
+
+        expected = torch.tensor([[0., 0., 0., 0.],
+                                 [0., 0., 0., 10.],
+                                 [0., 0., 0., 0.],
+                                 [0., 0., 0., 1.]], device=device, dtype=dtype)
+        check_allclose(tfms,
+                       expected.unsqueeze(0).expand(tfms.shape[0], -1, -1),
+                       atol=1e-4)
+
+    @pytest.mark.parametrize("apply_qr,normalize", [
+        (False, False), (False, True), (True, False), (True, True)],
+        ids=["plain", "normalize", "qr", "qr_and_normalize"])
+    def test_get_object_transforms_presim_matches_postforce(
+            self, example_rigid_cube, device, dtype, apply_qr, normalize):
+        """The pre-sim (sim_z=None) and post-force-setup (sim_z populated)
+        paths of _get_object_transforms_internal must agree, since both should
+        encode the same init_transform when no sim step has been taken yet."""
+        init = torch.tensor([[1, 0, 0, 0], [0, 1, 0, 10], [0, 0, 1, 0]],
+                            device=device, dtype=dtype)
+        scene = SimplicitsScene(device=device)
+        scene.add_object(example_rigid_cube, num_qp=200, init_transform=init,
+                         normalize_weights_by_samples=normalize, apply_qr=apply_qr)
+
+        assert scene.sim_z is None
+        presim_tfms = scene.get_object_transforms(0)
+
+        scene.set_scene_gravity()  # triggers reset_scene -> populates sim_z
+        assert scene.sim_z is not None
+        postsetup_tfms = scene.get_object_transforms(0)
+
+        check_allclose(presim_tfms, postsetup_tfms, atol=1e-4)
+
+    # ---- reset_sim_state populates obj.z correctly across mode combinations ----
+    # Regression: ensures the lstsq path (apply_qr=True) and the scale-by-norm
+    # path agree on the displacement they encode for the same init_transform,
+    # and continue to compose correctly when both flags are on.
+
+    @pytest.mark.parametrize("apply_qr,normalize", [
+        (False, False), (False, True), (True, False), (True, True)],
+        ids=["plain", "normalize", "qr", "qr_and_normalize"])
+    def test_reset_sim_state_z_matches_init_transform(
+            self, example_rigid_cube, device, dtype, apply_qr, normalize):
+        """obj.B_dense @ obj.z must reconstruct the rigid displacement implied
+        by init_transform, for every combination of conditioning flags. This
+        directly exercises the reset_sim_state branches."""
+        init = torch.tensor([[1, 0, 0, 0], [0, 1, 0, 10], [0, 0, 1, 0]],
+                            device=device, dtype=dtype)
+        scene = SimplicitsScene(device=device)
+        scene.add_object(example_rigid_cube, num_qp=200, init_transform=init,
+                         normalize_weights_by_samples=normalize, apply_qr=apply_qr)
+
+        obj = scene.get_object(0)
+        predicted_dx = (obj.B_dense @ obj.z).view(-1, 3)
+
+        # Rigid translation by (0, 10, 0) on the (subsampled) sim points.
+        expected_dx = torch.zeros_like(obj.pts)
+        expected_dx[:, 1] = 10.0
+
+        check_allclose(predicted_dx, expected_dx, atol=1e-4)
+
+    # ---- QR + collisions: basis-rotation invariance ----
+    # Regression: with apply_qr=True the collision Jacobian must be rotated into
+    # the post-QR basis (via sim_qr_tfm) and the line-search bounds must clamp
+    # in the raw basis (via the basis-change wrap in _apply_bounds). Otherwise the
+    # Newton solver mixes inconsistent bases and the trajectory drifts.
+
+    def _build_collision_scene(self, example_rigid_cube, device, dtype, *,
+                               apply_qr, floor_height=3.0, num_steps=20):
+        """Build a one-object scene with gravity, floor, and collisions; step it."""
+        torch.manual_seed(0)
+        scene = SimplicitsScene(device=device)
+        scene.timestep = 0.01
+        scene.newton_hessian_regularizer = 1e-5
+        scene.add_object(
+            example_rigid_cube, num_qp=200,
+            init_transform=torch.tensor([[1, 0, 0, 0],
+                                         [0, 1, 0, 5],
+                                         [0, 0, 1, 0]], device=device, dtype=dtype),
+            apply_qr=apply_qr)
+        scene.set_scene_gravity()
+        scene.set_scene_floor(floor_height=floor_height)
+        scene.reset_scene()
+        scene.enable_collisions(impenetrable_barrier_ratio=0.5, collision_penalty=100.0)
+        for _ in range(num_steps):
+            scene.run_sim_step()
+        return scene
+
+    def test_enable_collisions_with_qr_does_not_raise(self, example_rigid_cube, device, dtype):
+        """The Phase 1 guard (NotImplementedError when apply_qr=True meets
+        enable_collisions) must be gone now that collision_J is rotated."""
+        scene = self._build_collision_scene(
+            example_rigid_cube, device, dtype, apply_qr=True, num_steps=1)
+        assert scene.force_dict["collision"]["object"] is not None
+        # sim_qr_tfm must be present (any QR object -> non-None) and shape-compatible
+        assert scene.sim_qr_tfm is not None
+        assert scene.sim_qr_tfm.shape[0] == scene.sim_B.shape[1]
+
+    def test_qr_collisions_trajectory_invariance(self, example_rigid_cube, device, dtype):
+        """QR is a pure basis change. Running an identical scene with apply_qr={False,True}
+        must produce the same simulated-point positions: same gravity, same floor
+        contact, same Newton solution after Phase 2 fixes the basis mismatch."""
+        scene_plain = self._build_collision_scene(
+            example_rigid_cube, device, dtype, apply_qr=False, num_steps=20)
+        scene_qr = self._build_collision_scene(
+            example_rigid_cube, device, dtype, apply_qr=True, num_steps=20)
+
+        pts_plain = scene_plain.get_object_deformed_pts(0, points='simulated')
+        pts_qr = scene_qr.get_object_deformed_pts(0, points='simulated')
+        check_allclose(pts_plain, pts_qr, atol=1e-3)


### PR DESCRIPTION
…d fixes

- Apply QR decomposition to the skinning basis B; propagate the QR transform through the collision Jacobian and bounds code
- Normalize skinning weights by sample count
- Rename pmat_rinv; rework how the internal transform is set
- Add torch.no_grad() around Newton-Method physics calls (non-differentiable)
- In-place updates on leaf tensors; minor kinematic-object optimization
- Fix get_object_deformed_pts / get_object_point_transforms to return the internal transform for simulated points
- Tests: validation and combined-flag coverage for QR / weight-norm / scale; simplicits-vs-FEM comparison