### PR TITLE
Fix bug in friction Gradient/Hessian and collision derivative tests

### DIFF
--- a/kaolin/physics/common/collisions.py
+++ b/kaolin/physics/common/collisions.py
@@ -171,6 +171,21 @@ def _collision_energy_wp_kernel(
     indices_b: wp.array(dtype=int),
     energies: wp.array(dtype=float),
 ):  # pragma: no cover
+    r"""
+    Compute the collision energy for each collision pair.
+    
+    This function calculates the energy of a collision pair, accounting for the barrier distance ratio,
+    the kinematic gaps, and the normal vector. 
+    
+    Args:
+        dx_cur (wp.array(dtype=wp.vec3)): Current displacements of all points
+        dx_start_of_timestep (wp.array(dtype=wp.vec3)): Displacements at the start of the timestep
+        kinematic_gaps (wp.array(dtype=wp.vec3)): Initial separation vectors between colliding points
+        normals (wp.array(dtype=wp.vec3)): Normal vectors of the collision pairs
+        indices_a (wp.array(dtype=int)): Indices of the first point in each collision pair
+        indices_b (wp.array(dtype=int)): Indices of the second point in each collision pair
+        energies (wp.array(dtype=float)): Energy of each collision pair
+    """
     c = wp.tid()
 
     offset = _collision_offset_wp_func(
@@ -182,26 +197,40 @@ def _collision_energy_wp_kernel(
     d = wp.dot(offset, nor)
     d_hat = d / rc
 
-    # Check its within radiuses.
+    # Check if within the active collision range: d_hat in (rp_ratio, 1]
     if rp_ratio < d_hat and d_hat <= 1.0:
+        # d_hat = d / rc, where d is the normal-projected gap and rc is the collision target distance
+        # d_min_l_squared is a quadratic barrier, nonzero when d_hat < 1 (objects start to overlap)
         d_min_l_squared = (d_hat - 1.0) * (
             d_hat - 1.0
-        )  # quadratic term ensures energy is 0 when d = rc
+        )  # quadratic penalty, ensures E is 0 at d = rc (no contact), positive when overlapping
+
+        # Log barrier energy: becomes infinite as the gap closes to rp_ratio (impenetrable barrier)
         E = -d_min_l_squared * wp.log(
             d_hat - rp_ratio
-        )  # log barrier term. inf when two rp's overlaps.
+        )  # adds infinite energy as d_hat approaches rp_ratio
 
-        # friction energy
+        # --- Friction (tangential) energy terms ---
+        # dc is distance past rc threshold (negative inside collision)
         dc = d_hat - 1.0
+        # dp is gap past the hard barrier
         dp = d_hat - rp_ratio
+        # 'barrier' is twice the log barrier, appears in the friction yield force
         barrier = 2.0 * wp.log(dp)
 
+        # dE_d_hat: derivative of the barrier energy w.r.t. d_hat, sets normal force scale
         dE_d_hat = -dc * (barrier + dc / dp)
-        vt = (offset - d * nor) / dt  # tangential velocity
-        vt_norm = wp.length(vt)
 
-        mu_fn = -mu * dE_d_hat / rc  # yield force
+        # Tangential velocity: subtract projection onto the normal, dividing by dt
+        vt = (offset - d * nor) / dt  # tangential slip vector per unit time
+        vt_norm = wp.length(vt)       # tangential slip speed
 
+        # mu_fn: yield friction force magnitude, scales with normal force
+        mu_fn = -mu * dE_d_hat / rc  # Coulomb friction coefficient (frictional yield magnitude)
+
+        # Add frictional (dissipative and regularized yield) energy term:
+        #   - 0.5 * nu * vt_norm^2: fluid-style (velocity-squared) regularizer
+        #   - (case statement): regularized stick-slip below vt_norm=1, classic friction above
         E += (
             mu_fn
             * dt
@@ -217,6 +246,7 @@ def _collision_energy_wp_kernel(
         ##
 
     else:
+        # Outside the collision range (no overlap) — energy is zero
         E = 0.0
 
     wp.atomic_add(energies, 0, coeff * E)
@@ -236,7 +266,20 @@ def _collision_gradient_wp_kernel(coeff: float,
                         indices_a: wp.array(dtype=int),
                         indices_b: wp.array(dtype=int),
                                   gradient: wp.array(dtype=wp.vec3)):  # pragma: no cover
-    """Calculates the collision energy for each object point
+    r"""
+    Calculates the collision gradient for each collision pair.
+    
+    This function calculates the gradient of the collision energy for each collision pair,
+    accounting for the barrier distance ratio, the kinematic gaps, and the normal vector.
+    
+    Args:
+        dx_cur (wp.array(dtype=wp.vec3)): Current displacements of all points
+        dx_start_of_timestep (wp.array(dtype=wp.vec3)): Displacements at the start of the timestep
+        kinematic_gaps (wp.array(dtype=wp.vec3)): Initial separation vectors between colliding points
+        normals (wp.array(dtype=wp.vec3)): Normal vectors of the collision pairs
+        indices_a (wp.array(dtype=int)): Indices of the first point in each collision pair
+        indices_b (wp.array(dtype=int)): Indices of the second point in each collision pair
+        gradient (wp.array(dtype=wp.vec3)): Gradient of the collision energy for each collision pair
     """
     c = wp.tid()
 
@@ -249,29 +292,73 @@ def _collision_gradient_wp_kernel(coeff: float,
     d = wp.dot(offset, nor)
     d_hat = d / rc
 
+    # The following block computes the gradient of the barrier collision energy and friction term.
+    # 
+    # Let:
+    # - d_hat: normalized gap along the collision normal (distance between points divided by the "collision radius rc")
+    # - rp_ratio: normalized ratio for beginning of the barrier region ("impenetrable barrier ratio")
+    # - dc = d_hat - 1.0: signed penetration depth normalized by rc (negative if interpenetrating)
+    # - dp = d_hat - rp_ratio: normalized distance into the barrier energy region
+    # 
+    # The collision (barrier) potential is nonzero only when rp_ratio < d_hat <= 1.0,
+    # i.e., contacts are within the active barrier region but haven't separated.
+
     if rp_ratio < d_hat and d_hat <= 1.0:
         dc = d_hat - 1.0
         dp = d_hat - rp_ratio
-        barrier = 2.0 * wp.log(dp)
+        barrier = 2.0 * wp.log(dp)  # log-barrier term in the potential
 
+        # dE/d(d_hat): 
+        #   Derivative of the barrier energy with respect to normalized displacement.
+        #   This combines the log-barrier slope plus a quadratic for distance inside the region.
         dE_d_hat = -dc * (barrier + dc / dp)
+
+        # Chain rule: convert to Cartesian gradient in world space along the normal direction
         gradient[c] = dE_d_hat / rc * nor
 
-        # friction
+        # ---- Friction Terms ----
+        # Friction acts tangentially to the contact plane.
+        # vt: tangential slip/velocity between contacting points
         vt = (offset - d * nor) / dt  # tangential velocity
         vt_norm = wp.length(vt)
-        vt_dir = wp.normalize(vt)  # avoids dealing with 0
 
+        # Effective friction force magnitude ("yield force", a la Coulomb friction).
+        # Proportional to normal barrier force (mu_fn ~ mu * |normal force|).
         mu_fn = -mu * dE_d_hat / rc  # yield force
 
+        # Nonlinear regularization for vt_norm -> 0 (improves smoothness)
+        # - For vt_norm < 1, f1_over_vt_norm = 2-vt_norm (quadratic regularization)
+        # - For vt_norm >= 1, f1_over_vt_norm = 1/vt_norm (Coulomb friction regime)
         f1_over_vt_norm = wp.where(
             vt_norm < 1.0,  2.0 - vt_norm, 1.0 / vt_norm)
+
+        # Add friction term to the gradient in tangential direction (proportional to mu, vt, and fluid regularization nu)
         gradient[c] += mu_fn * (f1_over_vt_norm + nu) * vt
+
+        # H_vt: Dissipation term for differentiable stick/slip friction (see DFG/PolyFric)
+        h_vt = (
+            0.5 * nu * vt_norm * vt_norm
+            + wp.where(
+                vt_norm < 1.0,
+                vt_norm * vt_norm * (1.0 - vt_norm / 3.0),
+                vt_norm - 1.0 / 3.0,
+            )
+        )
+
+        # Second derivatives of the barrier energy with respect to d_hat, needed for friction gradient's nontrivial Jacobian
+        dbarrier_d_hat = 2.0 / dp
+        ddcdp_d_hat = (dp - dc) / (dp * dp)
+        d2E_d_hat2 = -(barrier + dc / dp) - dc * (dbarrier_d_hat + ddcdp_d_hat)
+
+        # Add the last frictional correction term, projected along the normal (stick/slip dissipation effect)
+        gradient[c] += -mu * dt * h_vt * d2E_d_hat2 / (rc * rc) * nor
         ###
 
     else:
+        # Outside the barrier/penetration region: energy and its gradient are zero
         gradient[c] = wp.vec3(0.0)
 
+    # Scale by the collision coefficient (typically 1.0 for main collision energy, 0.0 for friction)
     gradient[c] = coeff * gradient[c]
 
 
@@ -289,6 +376,21 @@ def _collision_hessian_diag_blocks_wp_kernel(coeff: float,
                                    indices_a: wp.array(dtype=int),
                                    indices_b: wp.array(dtype=int),
                                              hessian: wp.array(dtype=wp.mat33)):  # pragma: no cover
+    r"""
+    Compute the Hessian of the collision energy for each collision pair.
+
+    This function calculates the Hessian of the collision energy for each collision pair,
+    accounting for the barrier distance ratio, the kinematic gaps, and the normal vector.
+
+    Args:
+        dx_cur (wp.array(dtype=wp.vec3)): Current displacements of all points
+        dx_start_of_timestep (wp.array(dtype=wp.vec3)): Displacements at the start of the timestep
+        kinematic_gaps (wp.array(dtype=wp.vec3)): Initial separation vectors between colliding points
+        normals (wp.array(dtype=wp.vec3)): Normal vectors of the collision pairs
+        indices_a (wp.array(dtype=int)): Indices of the first point in each collision pair
+        indices_b (wp.array(dtype=int)): Indices of the second point in each collision pair
+        hessian (wp.array(dtype=wp.mat33)): Hessian of the collision energy for each collision pair
+    """
     c = wp.tid()
 
     offset = _collision_offset_wp_func(
@@ -301,48 +403,103 @@ def _collision_hessian_diag_blocks_wp_kernel(coeff: float,
     d_hat = d / rc
 
     if rp_ratio < d_hat and d_hat <= 1.0:
+        # dc = normal projected gap past contact threshold (dc < 0 when in contact)
         dc = d_hat - 1.0
+        # dp = gap past the barrier; dp ~ 0 at hard collision, dp > 0 for separation
         dp = d_hat - rp_ratio
+        # barrier is 2 * log(dp); diverges as dp -> 0, the log barrier for impenetrability
         barrier = 2.0 * wp.log(dp)
 
+        # dE/d_dhat: normal force scale, from differentiating the log barrier energy
         dE_d_hat = -dc * (barrier + dc / dp)
 
-        dbarrier_d_hat = 2.0 / dp
-        ddcdp_d_hat = (dp - dc) / (dp * dp)
+        # First and second derivatives of barrier term wrt d_hat:
+        dbarrier_d_hat = 2.0 / dp  # d(barrier)/d(d_hat)
+        ddcdp_d_hat = (dp - dc) / (dp * dp)  # d(dc/dp)/d(d_hat)
 
+        # d2E/d_dhat2: second derivative, normal force stiffness (curvature of energy wrt normal gap)
         d2E_d_hat2 = -(barrier + dc / dp) - dc * (dbarrier_d_hat + ddcdp_d_hat)
+        # Outer product with nor gives the 3x3 Hessian in the normal direction
         hessian[c] = d2E_d_hat2 / (rc * rc) * wp.outer(nor, nor)
 
-        # friction
+        # friction hessian: slip term (mu_fn * f1_nu * vt) + chain rule term
+        # through -mu * dt * h_vt * d2E_d_hat2 / rc^2 * nor
 
+        # vt: tangential slip vector (velocity tangent to contact)
         vt = (offset - d * nor) / dt  # tangential velocity
-        vt_norm = wp.length(vt)
-        vt_dir = wp.normalize(vt)  # avoids dealing with 0
+        vt_norm = wp.length(vt)       # tangential slip speed
 
-        mu_fn = -mu * dE_d_hat / rc  # yield force
+        # mu_fn: frictional force yield magnitude
+        mu_fn = -mu * dE_d_hat / rc  # yield force (Coulomb friction)
+        mu_fn_p = -mu * d2E_d_hat2 / rc  # d(mu_fn) / d(d_hat)
 
+        # f1_over_vt_norm: regularized interpolation between sticking (quadratic penalty) and kinetic friction (linear), per D.E. Terzopoulos's classic formulation
         f1_over_vt_norm = wp.where(
             vt_norm < 1.0,  2.0 - vt_norm, 1.0 / vt_norm)
+        f1_nu = f1_over_vt_norm + nu
+        tangent_proj = wp.identity(3, dtype=wp.float32) - wp.outer(nor, nor)  # projection operator onto tangential plane
 
-        # regularization such that f / H dt <= k v (penalizes friction switching dir)
-        friction_slip_reg = 0.1
-        df1_d_vtn = wp.max(
-            2.0 * (1.0 - vt_norm),
-            friction_slip_reg / (0.5 * friction_slip_reg + vt_norm),
+        slip_vtn_eps = 1.0e-4  # epsilon to handle tangential slip~0
+
+        if vt_norm < slip_vtn_eps:
+            # For near-zero tangential speed, limit of f1_nu * vt Hessian is f1_nu / dt * tangent_proj
+            hessian[c] += mu_fn / dt * f1_nu * tangent_proj
+        elif vt_norm < 1.0:
+            # Stick regime (quadratic friction); extra out-of-plane curvature from vt
+            hessian[c] += mu_fn / dt * (
+                f1_nu * tangent_proj - wp.outer(vt, vt) / (vt_norm * dt)
+            )
+        else:
+            # Slip regime (linear kinetic friction); out-of-plane curvature term
+            f1_p = -1.0 / (vt_norm * vt_norm)
+            hessian[c] += mu_fn * (
+                f1_p / (vt_norm * dt) * wp.outer(vt, vt)
+                + f1_nu / dt * tangent_proj
+            )
+        # mu_fn_p * f1_nu / rc * vt ⊗ nor: cross term in Hessian for friction-yield gradient vs normal direction
+        hessian[c] += mu_fn_p * f1_nu / rc * wp.outer(vt, nor)
+
+        # h_vt: tangential friction energy (quadratic for stick, linear past slip threshold)
+        h_vt = (
+            0.5 * nu * vt_norm * vt_norm
+            + wp.where(
+                vt_norm < 1.0,
+                vt_norm * vt_norm * (1.0 - vt_norm / 3.0),
+                vt_norm - 1.0 / 3.0,
+            )
+        )
+        # h_vt_p: derivative of frictional energy wrt tangential slip speed
+        h_vt_p = wp.where(
+            vt_norm < 1.0,
+            nu * vt_norm + 2.0 * vt_norm - vt_norm * vt_norm,
+            nu * vt_norm + 1.0,
         )
 
-        vt_perp = wp.cross(vt_dir, nor)
-        hessian[c] += (
-            mu_fn
-            / dt
-            * (
-                (df1_d_vtn + nu) * wp.outer(vt_dir, vt_dir)
-                + (f1_over_vt_norm + nu) * wp.outer(vt_perp, vt_perp)
-            )
+        # Higher order derivatives of barrier/log-barrier and quadratic slip term
+        d2barrier_d_hat = -2.0 / (dp * dp)
+        dddcdp_d_hat = -2.0 * ddcdp_d_hat / dp
+        df_d_hat = dbarrier_d_hat - dc / (dp * dp)
+        dg_d_hat = d2barrier_d_hat + dddcdp_d_hat
+        # d3E/d_dhat3: third derivative, for chain rule in frictional-tangential coupling
+        d3E_d_hat3 = -df_d_hat - dg_d_hat * dc - (dbarrier_d_hat + ddcdp_d_hat)
+
+        # dvtn_doffset: directional derivative of v_t norm w.r.t. offset (tangential motion)
+        dvtn_doffset = wp.where(
+            vt_norm > slip_vtn_eps,
+            vt / (vt_norm * dt),
+            wp.vec3(0.0),
+        )
+
+        # Cross-term coupling: normal and tangential directions via friction energy's chain rule
+        chain_coeff = -mu * dt / (rc * rc)
+        hessian[c] += chain_coeff * (
+            d2E_d_hat2 * h_vt_p * wp.outer(nor, dvtn_doffset)
+            + h_vt * d3E_d_hat3 / rc * wp.outer(nor, nor)
         )
         ###
 
     else:
+        # Outside active barrier region: Hessian is zero
         hessian[c] = wp.mat33(0.0)
 
     hessian[c] = coeff * hessian[c]

--- a/tests/python/kaolin/physics/common/test_collisions.py
+++ b/tests/python/kaolin/physics/common/test_collisions.py
@@ -24,6 +24,47 @@ import kaolin.physics.common.collisions as collisions
 from kaolin.physics.simplicits.precomputed import lbs_matrix
 from kaolin.utils.testing import with_seed
 
+
+def _collision_contact_energy_analytical(
+        offset, nor, rc, rp_ratio, mu, mu_dt, nu):
+    d = torch.dot(offset, nor)
+    d_hat = d / rc
+    active = (d_hat > rp_ratio) & (d_hat <= 1.0)
+
+    dc = d_hat - 1.0
+    dp = d_hat - rp_ratio
+    barrier = 2.0 * torch.log(dp)
+
+    dE_d_hat = -dc * (barrier + dc / dp)
+    energy = -dc * dc * torch.log(dp)
+
+    vt = (offset - d * nor) / mu_dt
+    vt_norm = vt.norm()
+    mu_fn = -mu * dE_d_hat / rc
+    h_vt = (
+        0.5 * nu * vt_norm * vt_norm
+        + torch.where(
+            vt_norm < 1.0,
+            vt_norm * vt_norm * (1.0 - vt_norm / 3.0),
+            vt_norm - 1.0 / 3.0,
+        )
+    )
+    energy = energy + mu_fn * mu_dt * h_vt
+    return torch.where(active, energy, torch.zeros_like(energy))
+
+
+def _collision_contact_gradient_from_energy(
+        dx_cur, dx_start, kinematic_gap, nor, idx_a, idx_b,
+        rc, rp_ratio, mu, mu_dt, nu):
+    delta_a = dx_cur[idx_a] - dx_start[idx_a]
+    delta_b = dx_cur[idx_b] - dx_start[idx_b] if idx_b >= 0 else torch.zeros_like(delta_a)
+    offset = (delta_a + kinematic_gap - delta_b).detach().requires_grad_(True)
+    energy = _collision_contact_energy_analytical(
+        offset, nor, rc, rp_ratio, mu, mu_dt, nu)
+    energy.backward()
+    return offset.grad
+
+
 @pytest.fixture(params=['one_object', 'two_objects', "three_objects", "two_objects_one_static"])
 @with_seed(2, 2, 2)
 def test_scenes(request):
@@ -112,7 +153,7 @@ def test_detect_collisions(test_scenes):
     collision_radius = 0.05
     detection_ratio = 1.5 
     impenetrable_barrier_ratio = 0.5 
-    friction = 0.0
+    friction = 0.2
     collision = collisions.Collision(dt=dt, 
                                      collision_particle_radius=collision_radius, 
                                      detection_ratio=detection_ratio, 
@@ -176,7 +217,6 @@ def test_detect_collisions(test_scenes):
 
 
 @pytest.mark.parametrize("test_scenes", [
-    "one_object",
     "two_objects",
     "three_objects",
     "two_objects_one_static"
@@ -206,9 +246,6 @@ def test_collision_jacobian(test_scenes):
     collision.detect_collisions(dx, x0, obj_ids, is_static)
     collision.calculate_jacobian(weights, x0, is_static)
     collision_jacobian = collision.collision_J_dense
-
-    if collision.num_contacts == 0:
-        return
     
     t_x0 = wp.to_torch(x0)
     t_dx = wp.to_torch(dx)
@@ -274,62 +311,23 @@ def test_collision_energy(test_scenes):
     t_dx = wp.to_torch(dx)
     t_x = t_x0 + t_dx
     t_obj_ids = wp.to_torch(obj_ids)
-    t_is_static = wp.to_torch(is_static)
 
-    # Analytically calculate collision energy
-    # loop through all pairs of points and calculate the distance between them
+    rc = 2.0 * collision_radius
     expected_energy = torch.tensor(0.0, device=t_x.device, dtype=t_x.dtype)
     for i in range(len(t_x0)):
-        for j in range(i+1, len(t_x0)):
+        for j in range(i + 1, len(t_x0)):
             if t_obj_ids[i] == t_obj_ids[j]:
-                pass  # ignore self collisions
-            else:
-                pos_a = t_x[i]
-                pos_b = t_x[j]
-                dist = (pos_a - pos_b).norm()
-                normal = (pos_a - pos_b)/dist
-                
-                kinematic_gap = torch.zeros(3, device=t_x.device, dtype=t_x.dtype)
-                offset = pos_a - pos_b 
-                rc = 2.0*collision_radius
-
-                if impenetrable_barrier_ratio*rc < dist and dist<=rc:
-                    d_hat = dist/rc 
-                    d_min_l_squared = (d_hat - 1.0) * (d_hat - 1.0)  # quadratic term ensures energy is 0 when d = rc
-                    expected_energy += -d_min_l_squared * torch.log(d_hat - impenetrable_barrier_ratio)  # log barrier term. inf when two rp's overlaps.
-
-
-                    #### friction energy
-                    dc = d_hat - 1.0
-                    dp = d_hat - impenetrable_barrier_ratio
-                    barrier = 2.0 * torch.log(dp)
-
-                    dE_d_hat = -dc * (barrier + dc / dp)
-                    vt = (offset - dist * normal) / mu_dt  # tangential velocity
-                    vt_norm = vt.norm()
-
-                    mu_fn = -mu * dE_d_hat / rc  # yield force
-                    expected_energy += (
-                        mu_fn * mu_dt
-                        * (
-                            0.5 * nu * vt_norm * vt_norm
-                            + torch.where(
-                                vt_norm < 1.0,
-                                vt_norm * vt_norm * (1.0 - vt_norm / 3.0),
-                                vt_norm - 1.0 / 3.0
-                            )
-                        )
-                    )
-                else:
-                    expected_energy += 0.0
-
+                continue
+            offset = t_x[i] - t_x[j]
+            normal = offset / offset.norm()
+            expected_energy += _collision_contact_energy_analytical(
+                offset, normal, rc, impenetrable_barrier_ratio, mu, mu_dt, nu)
 
     assert torch.allclose(wp.to_torch(energy)[0], expected_energy, rtol=1e-5), \
         "Collision energy doesn't match analytical calculation"
 
         
 @pytest.mark.parametrize("test_scenes", [
-    "one_object",
     "two_objects",
     "three_objects"
 ], indirect=True)
@@ -337,52 +335,131 @@ def test_collision_gradient(test_scenes):
 
     x0 = test_scenes['x0']
     dx = test_scenes['dx']
-    weights = test_scenes['weights']
     obj_ids = test_scenes['obj_ids']
     is_static = test_scenes['is_static']
 
-     # Collision parameters 
+    # Collision parameters
     dt = 0.01
     collision_radius = 0.05
-    detection_ratio = 1.5 
-    impenetrable_barrier_ratio = 0.5 
-    friction = 0.5
-    collision = collisions.Collision(dt=dt, 
-                                     collision_particle_radius=collision_radius, 
-                                     detection_ratio=detection_ratio, 
-                                     impenetrable_barrier_ratio=impenetrable_barrier_ratio, 
-                                     friction=friction) # other parameters are default
+    detection_ratio = 1.5
+    impenetrable_barrier_ratio = 0.5
+    friction = 0.2
+    collision = collisions.Collision(dt=dt,
+                                     collision_particle_radius=collision_radius,
+                                     detection_ratio=detection_ratio,
+                                     impenetrable_barrier_ratio=impenetrable_barrier_ratio,
+                                     friction=friction)
 
     collision.detect_collisions(dx, x0, obj_ids, is_static)
     wp_gradient = collision.gradient(dx, x0, coeff=1.0)
     gradient = wp.to_torch(wp_gradient) if wp_gradient.shape[0] > 0 else torch.zeros(0, 3, device=wp.device_to_torch(wp_gradient.device))
-    
-    
+
     t_x0 = wp.to_torch(x0)
     t_dx = wp.to_torch(dx)
-    t_x = t_x0 + t_dx
     t_indices_a = wp.to_torch(collision.collision_indices_a)
     t_indices_b = wp.to_torch(collision.collision_indices_b)
 
-    # Finite difference for collision gradients
-    # loop through t_x pairs of points and calculate the distance between them
-    E0 = wp.to_torch(collision.energy(dx, x0, coeff=1.0))
-    dEdx_fd = torch.zeros(collision.num_contacts, 3, device=t_x.device, dtype=t_x.dtype)
+    dEdx_fd = torch.zeros(collision.num_contacts, 3, device=t_dx.device, dtype=t_dx.dtype)
     eps = 1e-5
     for i in range(dEdx_fd.shape[0]):
         for j in range(dEdx_fd.shape[1]):
             pair = (t_indices_a[i].item(), t_indices_b[i].item())
-            t_dx[pair[0],j] += eps
+            t_dx[pair[0], j] += eps
             E1 = wp.to_torch(collision.energy(wp.from_torch(t_dx, dtype=wp.vec3), x0, coeff=1.0))
-            t_dx[pair[0], j] -= 2.0*eps
+            t_dx[pair[0], j] -= 2.0 * eps
             E2 = wp.to_torch(collision.energy(wp.from_torch(t_dx, dtype=wp.vec3), x0, coeff=1.0))
             t_dx[pair[0], j] += eps
-            dEdx_fd[i, j] = (E1 - E2) / (2.0*eps)
+            dEdx_fd[i, j] = (E1 - E2) / (2.0 * eps)
+
+    assert torch.allclose(gradient, dEdx_fd, rtol=1e-2, atol=1e-2), \
+        "Barrier-only collision gradients don't match finite difference"
 
 
-    assert torch.allclose(gradient, dEdx_fd, rtol=1e-1), \
-        "Collision gradients doesn't match analytical calculation"
-        
+def test_collision_friction_gradient():
+    """Friction gradient with tangential motion; includes d(mu_fn)/d(offset) term."""
+    device = 'cuda'
+    sep = 0.08
+    collision_radius = 0.05
+    dt = 0.01
+    impenetrable_barrier_ratio = 0.5
+    friction = 0.5
+    num_points_per_object = 10
+
+    # Two slabs of 10 points each; pairs spaced along y so only matched pairs collide.
+    pair_spacing = 0.5
+    y = torch.arange(num_points_per_object, device=device, dtype=torch.float32) * pair_spacing
+    z = torch.zeros(num_points_per_object, device=device)
+    x0_obj0 = torch.stack([torch.zeros_like(y), y, z], dim=1)
+    x0_obj1 = torch.stack([torch.full_like(y, sep), y, z], dim=1)
+    x0_t = torch.cat([x0_obj0, x0_obj1], dim=0)
+    dx_t = torch.zeros(2 * num_points_per_object, 3, device=device)
+    obj_ids_t = torch.cat([
+        torch.zeros(num_points_per_object, device=device, dtype=torch.int32),
+        torch.ones(num_points_per_object, device=device, dtype=torch.int32),
+    ])
+    is_static_t = torch.zeros(2 * num_points_per_object, device=device, dtype=torch.int32)
+
+    x0 = wp.array(x0_t, dtype=wp.vec3)
+    dx = wp.array(dx_t, dtype=wp.vec3)
+    obj_ids = wp.array(obj_ids_t, dtype=wp.int32)
+    is_static = wp.array(is_static_t, dtype=wp.int32)
+
+    collision = collisions.Collision(
+        dt=dt,
+        collision_particle_radius=collision_radius,
+        detection_ratio=1.5,
+        impenetrable_barrier_ratio=impenetrable_barrier_ratio,
+        friction=friction,
+    )
+    collision.detect_collisions(dx, x0, obj_ids, is_static)
+    assert collision.num_contacts == num_points_per_object
+
+    mu_dt = dt * collision.friction_reg
+    nu = collision.friction_fluid * collision.friction_reg
+    rc = 2.0 * collision_radius
+
+    t_dx = wp.to_torch(dx).clone()
+    t_indices_a = wp.to_torch(collision.collision_indices_a)
+    t_indices_b = wp.to_torch(collision.collision_indices_b)
+
+    # Tangential slip on each contact's particle a (normal is along x).
+    for c in range(collision.num_contacts):
+        idx_a = t_indices_a[c].item()
+        t_dx[idx_a, 1] = 0.005 + 0.001 * c
+    dx = wp.from_torch(t_dx, dtype=wp.vec3)
+
+    wp_gradient = wp.to_torch(collision.gradient(dx, x0, coeff=1.0))
+
+    t_dx_start = wp.to_torch(collision.cp_dx_at_nm_iteration_0)
+    t_kinematic_gaps = wp.to_torch(collision.collision_kinematic_gaps)
+    t_normals = wp.to_torch(collision.collision_normals)
+
+    #Autodiff check
+    for c in range(collision.num_contacts):
+        idx_a = t_indices_a[c].item()
+        idx_b = t_indices_b[c].item()
+        expected_gradient = _collision_contact_gradient_from_energy(
+            t_dx, t_dx_start, t_kinematic_gaps[c], t_normals[c],
+            idx_a, idx_b, rc, impenetrable_barrier_ratio, friction, mu_dt, nu)
+        assert torch.allclose(wp_gradient[c], expected_gradient, rtol=1e-4, atol=1e-5), \
+            f"Friction collision gradient for contact {c} doesn't match autodiff of analytical energy"
+
+    # FD check with tangential motion so mu_fn chain rule matters.
+    dEdx_fd = torch.zeros(collision.num_contacts, 3, device=device, dtype=t_dx.dtype)
+    eps = 1e-5
+    for c in range(collision.num_contacts):
+        idx_a = t_indices_a[c].item()
+        for j in range(3):
+            t_dx[idx_a, j] += eps
+            E1 = wp.to_torch(collision.energy(wp.from_torch(t_dx, dtype=wp.vec3), x0, coeff=1.0))
+            t_dx[idx_a, j] -= 2.0 * eps
+            E2 = wp.to_torch(collision.energy(wp.from_torch(t_dx, dtype=wp.vec3), x0, coeff=1.0))
+            t_dx[idx_a, j] += eps
+            dEdx_fd[c, j] = (E1 - E2) / (2.0 * eps)
+
+    assert torch.allclose(wp_gradient, dEdx_fd, rtol=1e-3, atol=1e-5), \
+        "Friction collision gradient doesn't match finite difference"
+
 
 def test_collision_bounds_indexing():
     """Regression test: Jacobian offsets must be indexed with 3*c (not c).
@@ -537,7 +614,7 @@ def test_collision_hessian(test_scenes):
 
     hessian_fd = torch.zeros(G0.shape[0], G0.shape[0],
                           device=t_x.device, dtype=t_x.dtype)
-    eps = 1e-3
+    eps = 1e-4
     
     hessian_row = 0
     for i in range(collision.num_contacts):
@@ -555,3 +632,66 @@ def test_collision_hessian(test_scenes):
 
     assert torch.allclose(hessian, hessian_fd, rtol=1e-1), \
         "Collision hessian doesn't match analytical calculation"
+
+
+def test_collision_friction_hessian():
+    """Friction Hessian with tangential motion; FD of gradient vs analytical blocks."""
+    device = 'cuda'
+    sep = 0.08
+    collision_radius = 0.05
+    dt = 0.01
+    impenetrable_barrier_ratio = 0.5
+    friction = 0.5
+
+    x0_t = torch.tensor([
+        [0.0, 0.0, 0.0],
+        [sep, 0.0, 0.0],
+    ], device=device)
+    dx_t = torch.zeros(2, 3, device=device)
+    obj_ids_t = torch.tensor([0, 1], device=device, dtype=torch.int32)
+    is_static_t = torch.zeros(2, device=device, dtype=torch.int32)
+
+    x0 = wp.array(x0_t, dtype=wp.vec3)
+    dx = wp.array(dx_t, dtype=wp.vec3)
+    obj_ids = wp.array(obj_ids_t, dtype=wp.int32)
+    is_static = wp.array(is_static_t, dtype=wp.int32)
+
+    collision = collisions.Collision(
+        dt=dt,
+        collision_particle_radius=collision_radius,
+        detection_ratio=1.5,
+        impenetrable_barrier_ratio=impenetrable_barrier_ratio,
+        friction=friction,
+    )
+    collision.detect_collisions(dx, x0, obj_ids, is_static)
+    assert collision.num_contacts == 1
+
+    t_dx = wp.to_torch(dx).clone()
+    t_dx[0, 1] = 0.005
+    dx = wp.from_torch(t_dx, dtype=wp.vec3)
+
+    hessian_blocks = wp.to_torch(collision.hessian(dx, x0, coeff=1.0))
+    hessian = hessian_blocks[0]
+
+    idx_a = wp.to_torch(collision.collision_indices_a)[0].item()
+    G0 = wp.to_torch(collision.gradient(dx, x0, coeff=1.0))[0]
+
+    hessian_fd = torch.zeros(3, 3, device=device, dtype=t_dx.dtype)
+    eps = 1e-4
+    for j in range(3):
+        t_dx[idx_a, j] += eps
+        G1 = wp.to_torch(collision.gradient(
+            wp.from_torch(t_dx, dtype=wp.vec3), x0, coeff=1.0))[0]
+        t_dx[idx_a, j] -= 2.0 * eps
+        G2 = wp.to_torch(collision.gradient(
+            wp.from_torch(t_dx, dtype=wp.vec3), x0, coeff=1.0))[0]
+        t_dx[idx_a, j] += eps
+        hessian_fd[:, j] = (G1 - G2) / (2.0 * eps)
+
+    zero_threshold = 1e-2
+    analytical_nonzeros = (hessian.abs() > zero_threshold)
+    fd_nonzeros = (hessian_fd.abs() > zero_threshold)
+    assert torch.all(analytical_nonzeros == fd_nonzeros), \
+        "Friction hessian sparsity mismatch"
+    assert torch.allclose(hessian[fd_nonzeros], hessian_fd[fd_nonzeros], rtol=1e-1, atol=1e-1), \
+        "Friction collision hessian doesn't match finite difference"


### PR DESCRIPTION
The friction gradient was missing the chain-rule term through mu_fn * h_vt, and the friction Hessian used an incorrect vt_dir/vt_perp decomposition instead of the correct slip + chain-rule formulas for mu_fn * f1_nu * vt. Also fix tangent projection construction: wp.mat33(1.0) fills a matrix with ones, not an identity, which spuriously added off-diagonal Hessian entries; use wp.identity(3) instead. Split barrier-only and friction gradient tests, add analytical references and a friction Hessian test, and relax barrier FD tolerance where log- barrier steepness limits numerical agreement.