### PR TITLE
Adding feature import/export to ply

### DIFF
--- a/ci/gitlab_jenkins_templates/ubuntu_test_cuda_CI.jenkins
+++ b/ci/gitlab_jenkins_templates/ubuntu_test_cuda_CI.jenkins
@@ -406,7 +406,9 @@ echo "Driver compat OK: cuda=\$CUDA need>=\$MIN have=\$DRV (max claimed: \$DRV_M
             export KAOLIN_TEST_SHREC16_PATH=/mnt/data/ci_shrec16
             export KAOLIN_TEST_GSPLATS_DIR=/mnt/gsplats
             export KAOLIN_SCANNED_TOYS_PATH=/mnt/data/toys/
+            export KAOLIN_TENSOR_IR_PATH=/mnt/data/tensor_ir/
             export KAOLIN_TEST_SCANNED_TOYS=1
+            export KAOLIN_TEST_TENSOR_IR=1
             pytest --durations=50 --import-mode=importlib -rs --cov=/kaolin/kaolin \
                 --log-disable=PIL.PngImagePlugin \
                 --log-disable=PIL.TiffImagePlugin \

--- a/kaolin/io/ply.py
+++ b/kaolin/io/ply.py
@@ -84,6 +84,27 @@ def import_gaussiancloud(filename: str,
     for idx, attr_name in enumerate(rot_names):
         mogt_rotation[:, idx] = np.asarray(plydata.elements[0][attr_name])
 
+    # Detect any `{base}_{int}` properties not consumed by the standard schema; these are
+    # surfaced via the `features` dict on the returned GaussianSplatModel.
+    consumed = {'x', 'y', 'z', 'nx', 'ny', 'nz', 'opacity',
+                'f_dc_0', 'f_dc_1', 'f_dc_2'}
+    consumed.update(extra_f_names)
+    consumed.update(scale_names)
+    consumed.update(rot_names)
+
+    extra_groups = {}
+    for p in plydata.elements[0].properties:
+        name = p.name
+        if name in consumed:
+            continue
+        base, sep, idx_str = name.rpartition('_')
+        if not sep:
+            continue
+        try:
+            idx = int(idx_str)
+        except ValueError:
+            continue
+        extra_groups.setdefault(base, []).append((idx, name))
 
     tensor_kwargs = {'dtype': torch.float32} # consistent with our exporter
     densities = torch.tensor(mogt_densities, **tensor_kwargs)
@@ -97,6 +118,16 @@ def import_gaussiancloud(filename: str,
     sh_coeff = torch.cat([torch.tensor(mogt_albedo, **tensor_kwargs).transpose(1, 2),
                         torch.tensor(mogt_specular, **tensor_kwargs).transpose(1, 2)], dim=1)
 
+    features = None
+    if extra_groups:
+        features = {}
+        for base, items in extra_groups.items():
+            items.sort()
+            arr = np.zeros((num_gaussians, len(items)))
+            for col, (_, attr_name) in enumerate(items):
+                arr[:, col] = np.asarray(plydata.elements[0][attr_name])
+            features[base] = torch.tensor(arr, **tensor_kwargs)
+
     kwargs = {
         'positions': torch.tensor(mogt_pos, **tensor_kwargs),
         'orientations': rotations,
@@ -104,11 +135,13 @@ def import_gaussiancloud(filename: str,
         'opacities': densities.squeeze(-1),
         'sh_coeff': sh_coeff
     }
+    if features is not None:
+        kwargs['features'] = features
     return GaussianSplatModel(**kwargs)
 
 
 def export_gaussiancloud(file_path, positions, orientations, scales, opacities,
-                         sh_coeff, sh_degree=None, overwrite=False):
+                         sh_coeff, features=None, sh_degree=None, overwrite=False):
     """Write a 3D Gaussian splatting-style PLY (``f_dc_*``, ``f_rest_*``, ``opacity``, ``scale_*``, ``rot_*``).
 
     Values are stored in the same raw space expected by :func:`import_gaussiancloud` when
@@ -123,11 +156,19 @@ def export_gaussiancloud(file_path, positions, orientations, scales, opacities,
         opacities (torch.Tensor): opacity of each gaussian, of shape :math:`(\text{num_gaussians})`.
         sh_coeff (torch.Tensor): spherical harmonics coefficients of each gaussian,
             of shape :math:`(\text{num_gaussians}, (\text{num_degrees} + 1)^2, 3)`.
+        features (dict, optional): extra per-gaussian fields to serialize alongside the standard
+            schema. Must be a ``dict`` mapping ``str`` name -> ``torch.Tensor`` of shape
+            :math:`(\text{num_gaussians}, K)`. Each entry is written as flat properties
+            ``{name}_0 ... {name}_{K-1}`` and is round-trippable through
+            :func:`import_gaussiancloud` (which restores it under ``GaussianSplatModel.features[name]``).
+            Defaults to ``None``.
         sh_degree (int): optionally pass for sanity checking, otherwise will guess the value
         overwrite (bool, optional): whether to overwrite the file if it already exists. Defaults to False.
 
     Raises:
         RuntimeError: if the file already exists and overwrite is False.
+        ValueError: if ``features`` has an invalid type/shape or a key collides with the
+            standard schema prefixes.
     """
     if not overwrite and os.path.exists(file_path):
         raise RuntimeError(f'Cannot overwrite: {file_path}')
@@ -172,10 +213,34 @@ def export_gaussiancloud(file_path, positions, orientations, scales, opacities,
     for i in range(rotation_np.shape[1]):
         l.append(f'rot_{i}')
 
+    feature_arrays = []
+    if features is not None:
+        if not isinstance(features, dict):
+            raise ValueError(
+                f'features must be a dict of (N, K) tensors, got {type(features).__name__}')
+        reserved_prefixes = ('f_dc', 'f_rest', 'scale', 'rot', 'x', 'y', 'z', 'nx', 'ny', 'nz', 'opacity')
+        for name, tensor in features.items():
+            if not isinstance(name, str):
+                raise ValueError(f'features keys must be str, got {type(name).__name__}')
+            if name in reserved_prefixes or any(name.startswith(p + '_') for p in reserved_prefixes):
+                raise ValueError(
+                    f'features key "{name}" collides with the standard PLY schema; '
+                    f'choose a name that is not one of {reserved_prefixes} or starts with one of them')
+            if not torch.is_tensor(tensor):
+                raise ValueError(
+                    f'features["{name}"] must be a torch.Tensor, got {type(tensor).__name__}')
+            if tensor.dim() != 2 or tensor.shape[0] != n:
+                raise ValueError(
+                    f'features["{name}"] must have shape (N={n}, K), got {tuple(tensor.shape)}')
+            arr = tensor.detach().float().cpu().numpy()
+            for i in range(arr.shape[1]):
+                l.append(f'{name}_{i}')
+            feature_arrays.append(arr)
+
     dtype_full = [(attribute, 'f4') for attribute in l]
     elements = np.empty(n, dtype=dtype_full)
     attributes = np.concatenate(
-        (xyz, normals, f_dc, f_rest_flat, opacities_np, scale_np, rotation_np), axis=1)
+        (xyz, normals, f_dc, f_rest_flat, opacities_np, scale_np, rotation_np, *feature_arrays), axis=1)
     elements[:] = list(map(tuple, attributes))
     el = PlyElement.describe(elements, 'vertex')
     PlyData([el]).write(file_path)

--- a/kaolin/utils/bundled_data.py
+++ b/kaolin/utils/bundled_data.py
@@ -24,7 +24,8 @@ import zipfile
 from kaolin.utils.env_vars import KaolinEnvVars
 
 __all__ = ['BUNDLED_DATA_PATH', 'SAMPLE_MESHES_PATH', 'SCANNED_TOYS_PATH', 'SCANNED_TOYS_NAMES',
-           'download_scanned_toys_dataset']
+           'TENSOR_IR_PATH', 'TENSOR_IR_NAMES',
+           'download_scanned_toys_dataset', 'download_tensor_ir_dataset']
 
 # TODO: add our meshes to manifest to make them available
 #: Absolute path to the ``sample_data`` tree shipped with Kaolin (meshes, scanned toys, etc.).
@@ -45,6 +46,14 @@ SCANNED_TOYS_PATH = os.getenv(KaolinEnvVars.SCANNED_TOYS_PATH) or os.path.join(B
 #: The dataset also includes a combined ``BluehairRagdoll_multi.usdc`` (two Gaussian clouds: original and transformed)
 #: and ``BluehairRagdoll_compressed.usdc`` (same clouds in float16, spherical harmonics degree 0).
 SCANNED_TOYS_NAMES = ['BluehairRagdoll', 'bublik_octopus', 'knit_meow', 'mer_elephant', 'stink_raccoon', 'sunflower_baby']
+
+#: Bundled tensor-IR assets directory: by default ``sample_data/tensor_ir`` relative to the
+#: repo root in a source checkout, unless overridden with ``KAOLIN_TENSOR_IR_PATH``.
+TENSOR_IR_PATH = os.getenv(KaolinEnvVars.TENSOR_IR_PATH) or os.path.join(BUNDLED_DATA_PATH, 'tensor_ir')  #: :meta hide-value:
+
+#: Tensor-IR sample identifiers matching ``.ply`` files under :py:data:`TENSOR_IR_PATH`.
+#: Prefixed with ``tensorir_`` so they don't collide with other ficus/lego variants kaolin tests use.
+TENSOR_IR_NAMES = ['tensorir_ficus', 'tensorir_lego']
 
 # Expected MD5 hex digests for toy Gaussian ``.usdc`` files under ``SCANNED_TOYS_PATH``.
 _TOYS_USDC_CHECKSUMS = {
@@ -89,6 +98,11 @@ _TOYS_MESH_CHECKSUMS = {
     'mesh.sunflower_baby.usd': '64f7e5a042dd4e0f76402d9819aedeaa',
 }
 
+# Expected MD5 hex digests for tensor-IR sample ``.ply`` files under ``TENSOR_IR_PATH``.
+_TENSOR_IR_PLY_CHECKSUMS = {
+    'tensorir_ficus.ply': '2c2c3bf45dd26038e84acca32cd95a74',
+    'tensorir_lego.ply': 'f382c20a563877b97a953537e90c8410',
+}
 
 # TODO: document details, point to a whitepaper when available
 def download_scanned_toys_dataset():
@@ -140,3 +154,48 @@ def download_scanned_toys_dataset():
                         _TOYS_MESH_CHECKSUMS)
 
     return SCANNED_TOYS_PATH
+
+
+def download_tensor_ir_dataset():
+    """Downloads Tensor-IR sample PLYs (real gaussians with per-point features)."""
+    def _have_expected_files(file_to_checksum, return_reason=False):
+        have_all = True
+        msg = ''
+        for file_name, md5_checksum in file_to_checksum.items():
+            path = os.path.join(TENSOR_IR_PATH, file_name)
+            if not os.path.exists(path):
+                if return_reason:
+                    msg = f'missing {path}'
+                have_all = False
+                break
+            with open(path, 'rb') as f:
+                if md5_checksum != hashlib.md5(f.read()).hexdigest():
+                    if return_reason:
+                        msg = f'md5 mismatch for {path}, expected: {md5_checksum}'
+                    have_all = False
+                    break
+        if return_reason:
+            return have_all, msg
+        return have_all
+
+    def _wget_unzip(url):
+        file_basename = os.path.basename(url)
+        target_filename = os.path.join(TENSOR_IR_PATH, file_basename)
+        wget.download(url, target_filename)
+        with zipfile.ZipFile(target_filename, 'r') as zip_ref:
+            zip_ref.extractall(TENSOR_IR_PATH)
+        os.remove(target_filename)
+
+    def _download_if_needed(url, expected_file_checksums):
+        if not _have_expected_files(expected_file_checksums):
+            _wget_unzip(url)
+            have_all, msg = _have_expected_files(expected_file_checksums, return_reason=True)
+            assert have_all, f'After download of {url}, still file mismatch: {msg}'
+
+    if not os.path.exists(TENSOR_IR_PATH):
+        os.makedirs(TENSOR_IR_PATH, exist_ok=True)
+
+    _download_if_needed('https://nvidia-kaolin.s3.us-east-2.amazonaws.com/data/tensor_ir.ply.zip',
+                        _TENSOR_IR_PLY_CHECKSUMS)
+
+    return TENSOR_IR_PATH

--- a/kaolin/utils/env_vars.py
+++ b/kaolin/utils/env_vars.py
@@ -25,6 +25,7 @@ class KaolinTestEnvVars(str, Enum):
     # TODO: replace hard-coded strings with these in all the tests --> we have too many hidden env vars controlling behavior
     # Test datasets and assets
     TEST_SCANNED_TOYS = 'KAOLIN_TEST_SCANNED_TOYS'
+    TEST_TENSOR_IR = 'KAOLIN_TEST_TENSOR_IR'
     TEST_GSPLATS_DIR = 'KAOLIN_TEST_GSPLATS_DIR'
     TEST_MODELNET_PATH = 'KAOLIN_TEST_MODELNET_PATH'
     TEST_SHAPENETV1_PATH = 'KAOLIN_TEST_SHAPENETV1_PATH'
@@ -44,3 +45,9 @@ class KaolinEnvVars(str, Enum):
     #: location exposed as :py:data:`~kaolin.utils.bundled_data.SCANNED_TOYS_PATH`
     #: (typically under ``sample_data`` in a source checkout).
     SCANNED_TOYS_PATH = 'KAOLIN_SCANNED_TOYS_PATH'
+
+    #: Filesystem path to the root directory of the tensor-IR sample dataset.
+    #: Set ``KAOLIN_TENSOR_IR_PATH`` in the shell to override the default location
+    #: exposed as :py:data:`~kaolin.utils.bundled_data.TENSOR_IR_PATH`
+    #: (typically under ``sample_data`` in a source checkout).
+    TENSOR_IR_PATH = 'KAOLIN_TENSOR_IR_PATH'

--- a/sample_data/.gitignore
+++ b/sample_data/.gitignore
@@ -1,1 +1,2 @@
 scanned_toys
+tensor_ir

--- a/tests/python/kaolin/io/test_ply.py
+++ b/tests/python/kaolin/io/test_ply.py
@@ -16,16 +16,20 @@
 import os
 import shutil
 import math
+import numpy as np
 import torch
 import pytest
+from plyfile import PlyData, PlyElement
 
 from kaolin.io import ply
 from kaolin.rep import GaussianSplatModel
-from kaolin.utils.bundled_data import SCANNED_TOYS_PATH, SCANNED_TOYS_NAMES, download_scanned_toys_dataset
+from kaolin.utils.bundled_data import (SCANNED_TOYS_PATH, SCANNED_TOYS_NAMES, download_scanned_toys_dataset,
+                                       TENSOR_IR_PATH, TENSOR_IR_NAMES, download_tensor_ir_dataset)
 from kaolin.utils.env_vars import KaolinTestEnvVars
 from kaolin.utils.testing import contained_torch_equal, with_seed
 
 TEST_SCANNED_TOYS = os.getenv(KaolinTestEnvVars.TEST_SCANNED_TOYS)
+TEST_TENSOR_IR = os.getenv(KaolinTestEnvVars.TEST_TENSOR_IR)
 
 _GAUSSIAN_KEYS = ('positions', 'orientations', 'scales', 'opacities', 'sh_coeff')
 
@@ -131,35 +135,35 @@ class TestGaussianImportFromToysPly:
 
     @pytest.mark.parametrize('toy_name', SCANNED_TOYS_NAMES)
     def test_import_toy_file(self, toy_name):
-        """Import gaussians from each toy PLY file and validate cloud structure."""
+        """Import gaussians from each toy PLY file and validate structure."""
         path = os.path.join(SCANNED_TOYS_PATH, f'{toy_name}.ply')
-        cloud = ply.import_gaussiancloud(path)
-        assert cloud.check_sanity()
+        gaussians = ply.import_gaussiancloud(path)
+        assert gaussians.check_sanity()
 
     @pytest.mark.parametrize('toy_name', SCANNED_TOYS_NAMES)
     def test_import_gaussiancloud_default(self, toy_name):
-        """``import_gaussiancloud`` returns a single cloud dict for the file."""
+        """``import_gaussiancloud`` returns a single GaussianSplatModel for the file."""
         path = os.path.join(SCANNED_TOYS_PATH, f'{toy_name}.ply')
-        cloud = ply.import_gaussiancloud(path)
-        assert isinstance(cloud, GaussianSplatModel)
-        assert cloud.check_sanity()
+        gaussians = ply.import_gaussiancloud(path)
+        assert isinstance(gaussians, GaussianSplatModel)
+        assert gaussians.check_sanity()
 
     @pytest.mark.parametrize('toy_name', SCANNED_TOYS_NAMES)
     def test_import_export_roundtrip_from_toy(self, out_dir, toy_name):
-        """Import cloud from toy PLY, export to a temp PLY, re-import and compare."""
+        """Import gaussians from toy PLY, export to a temp PLY, re-import and compare."""
         path = os.path.join(SCANNED_TOYS_PATH, f'{toy_name}.ply')
-        cloud = ply.import_gaussiancloud(path)
+        gaussians = ply.import_gaussiancloud(path)
 
         out_path = os.path.join(out_dir, f'gaussian_roundtrip_{toy_name}.ply')
         ply.export_gaussiancloud(
             out_path,
-            **cloud.as_dict(only_tensors=True),
+            **gaussians.as_dict(only_tensors=True),
             overwrite=True,
         )
 
         reimported = ply.import_gaussiancloud(out_path)
 
-        assert contained_torch_equal(cloud.as_dict(), reimported.as_dict(),
+        assert contained_torch_equal(gaussians.as_dict(), reimported.as_dict(),
                                      approximate=True, print_error_context=''), f'Mismatch for toy {toy_name}'
 
     @pytest.mark.parametrize('toy_name', SCANNED_TOYS_NAMES)
@@ -175,3 +179,192 @@ class TestGaussianImportFromToysPly:
 
         assert contained_torch_equal(actual.as_dict(only_tensors=True), expected,
                                      approximate=True, print_error_context=''), f'Mismatch for toy {toy_name}'
+
+
+# -------------------------------------------------------------------------------
+# Tests that run with custom feature options, toys and material objects needed
+# -------------------------------------------------------------------------------
+
+EXPECTED_FEATURES_PER_SHAPE = {
+    'tensorir_ficus': {'albedo': 3, 'normal': 3, 'metallic': 1, 'roughness': 1},
+    'tensorir_lego':  {'albedo': 3, 'normal': 3, 'metallic': 1, 'roughness': 1, 'segment': 1},
+}
+
+
+def _tensor_ir_path(name):
+    return os.path.join(TENSOR_IR_PATH, f'{name}.ply')
+
+
+@pytest.mark.skipif(
+    TEST_SCANNED_TOYS is None or TEST_TENSOR_IR is None,
+    reason=("'KAOLIN_TEST_SCANNED_TOYS' and 'KAOLIN_TEST_TENSOR_IR' environment variables "
+            "must both be set (will download toys, and verify presence of tensor-IR samples)."),
+)
+class TestGaussianFeaturesPly:
+    """Tests for the optional ``features`` dict in :mod:`kaolin.io.ply`."""
+
+    @pytest.fixture(scope='class', autouse=True)
+    def download_datasets(self):
+        download_scanned_toys_dataset()
+        download_tensor_ir_dataset()
+
+    @staticmethod
+    def _export(out_path, data, features=None):
+        ply.export_gaussiancloud(
+            out_path,
+            positions=data['positions'],
+            orientations=data['orientations'],
+            scales=data['scales'],
+            opacities=data['opacities'],
+            sh_coeff=data['sh_coeff'],
+            features=features,
+            overwrite=True,
+        )
+
+    @pytest.mark.parametrize('toy_name', SCANNED_TOYS_NAMES)
+    def test_import_toy_has_no_features(self, toy_name):
+        """Vanilla 3DGS toy PLYs have no extra properties and must import as features=None."""
+        path = os.path.join(SCANNED_TOYS_PATH, f'{toy_name}.ply')
+        assert ply.import_gaussiancloud(path).features is None
+
+    @pytest.mark.parametrize('name', TENSOR_IR_NAMES)
+    def test_import_features_from_disk(self, name):
+        """Real gaussian PLYs with extra per-point channels import with the expected feature schema."""
+        gaussians = ply.import_gaussiancloud(_tensor_ir_path(name))
+        expected = EXPECTED_FEATURES_PER_SHAPE[name]
+        assert gaussians.check_sanity()
+        assert isinstance(gaussians.features, dict)
+        assert set(gaussians.features.keys()) == set(expected.keys())
+        for key, k in expected.items():
+            feat = gaussians.features[key]
+            assert isinstance(feat, torch.Tensor), \
+                f'{name}: features[{key!r}] is {type(feat).__name__}, expected torch.Tensor'
+            assert feat.device.type == 'cpu', \
+                f'{name}: features[{key!r}] on device {feat.device}, expected cpu'
+            assert feat.shape == (len(gaussians), k), \
+                f'{name}: features[{key!r}] shape {feat.shape} != (N={len(gaussians)}, K={k})'
+
+    @pytest.mark.parametrize('name', TENSOR_IR_NAMES)
+    def test_features_roundtrip_from_disk(self, out_dir, name):
+        """Round-trip a real gaussian PLY with extra features (import -> export -> reimport)."""
+        gaussians = ply.import_gaussiancloud(_tensor_ir_path(name))
+        out_path = os.path.join(out_dir, f'roundtrip_{name}.ply')
+        ply.export_gaussiancloud(out_path, **gaussians.as_dict(only_tensors=True), overwrite=True)
+        reimported = ply.import_gaussiancloud(out_path)
+        assert contained_torch_equal(gaussians.as_dict(), reimported.as_dict(),
+                                     approximate=True, print_error_context=''), f'Mismatch for {name}'
+
+    def test_no_features_import_returns_none(self, out_dir):
+        data = make_synthetic_gaussian_cloud(n=8, seed=0)
+        out_path = os.path.join(out_dir, 'gauss_no_features.ply')
+        self._export(out_path, data)
+        assert ply.import_gaussiancloud(out_path).features is None
+
+    def test_features_roundtrip_single(self, out_dir):
+        data = make_synthetic_gaussian_cloud(n=8, seed=0)
+        features = {'mat': torch.randn(8, 4, dtype=torch.float32)}
+        out_path = os.path.join(out_dir, 'gauss_features_single.ply')
+        self._export(out_path, data, features=features)
+
+        imported = ply.import_gaussiancloud(out_path)
+        assert contained_torch_equal(features, imported.features, approximate=True, print_error_context='')
+
+    def test_features_roundtrip_multiple(self, out_dir):
+        data = make_synthetic_gaussian_cloud(n=8, seed=0)
+        features = {
+            'albedo': torch.randn(8, 3, dtype=torch.float32),
+            'roughness': torch.randn(8, 1, dtype=torch.float32),
+            'lobe': torch.randn(8, 7, dtype=torch.float32),
+        }
+        out_path = os.path.join(out_dir, 'gauss_features_multi.ply')
+        self._export(out_path, data, features=features)
+
+        imported = ply.import_gaussiancloud(out_path)
+        assert contained_torch_equal(features, imported.features, approximate=True, print_error_context='')
+
+    def test_features_roundtrip_name_with_underscore(self, out_dir):
+        """Feature names containing underscores group on the last underscore."""
+        data = make_synthetic_gaussian_cloud(n=8, seed=0)
+        features = {'my_extra_feat': torch.randn(8, 3, dtype=torch.float32)}
+        out_path = os.path.join(out_dir, 'gauss_features_underscore.ply')
+        self._export(out_path, data, features=features)
+
+        imported = ply.import_gaussiancloud(out_path)
+        assert contained_torch_equal(features, imported.features, approximate=True, print_error_context='')
+
+    def test_features_import_recovers_shuffled_columns(self, out_dir):
+        """Importer must restore column order by the integer suffix, regardless of property order."""
+        data = make_synthetic_gaussian_cloud(n=8, seed=0)
+        features = {'foo': torch.randn(8, 3, dtype=torch.float32)}
+        out_path = os.path.join(out_dir, 'gauss_features_shuffled.ply')
+        self._export(out_path, data, features=features)
+
+        plydata = PlyData.read(out_path)
+        elem = plydata.elements[0]
+        order = [p.name for p in elem.properties]
+        i0, i1, i2 = order.index('foo_0'), order.index('foo_1'), order.index('foo_2')
+        order[i0], order[i2] = order[i2], order[i0]
+        reordered = np.empty(elem.data.shape, dtype=[(n, elem.data.dtype[n]) for n in order])
+        for n in order:
+            reordered[n] = elem.data[n]
+        shuffled_path = os.path.join(out_dir, 'gauss_features_shuffled_after.ply')
+        PlyData([PlyElement.describe(reordered, 'vertex')]).write(shuffled_path)
+
+        imported = ply.import_gaussiancloud(shuffled_path)
+        assert contained_torch_equal(features, imported.features, approximate=True, print_error_context='')
+
+    def test_import_ignores_non_indexed_extra_property(self, out_dir):
+        """Extra PLY properties without a ``_<int>`` suffix must not crash or appear in features."""
+        data = make_synthetic_gaussian_cloud(n=8, seed=0)
+        out_path = os.path.join(out_dir, 'gauss_features_extra.ply')
+        self._export(out_path, data)
+
+        plydata = PlyData.read(out_path)
+        elem = plydata.elements[0]
+        names = [p.name for p in elem.properties] + ['extra_metadata']
+        extended = np.empty(elem.data.shape, dtype=[(n, 'f4') for n in names])
+        for p in elem.properties:
+            extended[p.name] = elem.data[p.name]
+        extended['extra_metadata'] = np.zeros(elem.data.shape, dtype='f4')
+        extended_path = os.path.join(out_dir, 'gauss_features_with_metadata.ply')
+        PlyData([PlyElement.describe(extended, 'vertex')]).write(extended_path)
+
+        assert ply.import_gaussiancloud(extended_path).features is None
+
+    def test_export_rejects_non_dict_features(self, out_dir):
+        data = make_synthetic_gaussian_cloud(n=8, seed=0)
+        out_path = os.path.join(out_dir, 'gauss_features_bad_type.ply')
+        with pytest.raises(ValueError):
+            self._export(out_path, data, features=[torch.zeros(8, 3)])
+
+    def test_export_rejects_non_string_key(self, out_dir):
+        data = make_synthetic_gaussian_cloud(n=8, seed=0)
+        out_path = os.path.join(out_dir, 'gauss_features_bad_key.ply')
+        with pytest.raises(ValueError):
+            self._export(out_path, data, features={1: torch.zeros(8, 3)})
+
+    @pytest.mark.parametrize('name', ['opacity', 'f_dc', 'f_dc_extra', 'f_rest_99', 'scale_x', 'rot_w', 'x', 'nx'])
+    def test_export_rejects_reserved_key(self, out_dir, name):
+        data = make_synthetic_gaussian_cloud(n=8, seed=0)
+        out_path = os.path.join(out_dir, f'gauss_features_reserved_{name}.ply')
+        with pytest.raises(ValueError):
+            self._export(out_path, data, features={name: torch.zeros(8, 3)})
+
+    def test_export_rejects_non_tensor_value(self, out_dir):
+        data = make_synthetic_gaussian_cloud(n=8, seed=0)
+        out_path = os.path.join(out_dir, 'gauss_features_bad_value.ply')
+        with pytest.raises(ValueError):
+            self._export(out_path, data, features={'mat': np.zeros((8, 3), dtype=np.float32)})
+
+    def test_export_rejects_wrong_rank(self, out_dir):
+        data = make_synthetic_gaussian_cloud(n=8, seed=0)
+        out_path = os.path.join(out_dir, 'gauss_features_bad_rank.ply')
+        with pytest.raises(ValueError):
+            self._export(out_path, data, features={'mat': torch.zeros(8)})
+
+    def test_export_rejects_wrong_point_count(self, out_dir):
+        data = make_synthetic_gaussian_cloud(n=8, seed=0)
+        out_path = os.path.join(out_dir, 'gauss_features_bad_n.ply')
+        with pytest.raises(ValueError):
+            self._export(out_path, data, features={'mat': torch.zeros(7, 3)})
+


### PR DESCRIPTION
Import now auto-detects and groups extra per-point properties into feature channels on loaded models.
Export accepts optional per-point feature tensors, validates inputs, and writes them as indexed flat properties in PLY outputs.


